### PR TITLE
BLD: Update Manifest and nosetests config

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
 include LICENSE
 graft include
+prune _skbuild
 global-exclude *.py[co]

--- a/meta.yaml
+++ b/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - scikit-build
     - setuptools_scm
   run:
-    - numpy
+    - 'numpy<1.16.1'
     - matplotlib
     - openmp
     - python={{ python }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,4 @@
 cover-package=tike
 verbosity=2
 with-coverage=1
+where=tests


### PR DESCRIPTION
Adding the where param makes nosetest called from the root directory execute in the correct place, and updated manifest removes build junk from install.