### PR TITLE
DOC: Add warning to plot_phase about zero-amplitudes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,8 @@ jobs:
   steps:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: Add conda to PATH
+  - bash: sudo chown -R $USER $CONDA
+    displayName: Take ownership of conda installation
   - bash: >
       conda create --yes --quiet --name $(package_name)
       python=$(python.version)

--- a/src/tike/view.py
+++ b/src/tike/view.py
@@ -63,6 +63,7 @@ __all__ = [
 ]
 
 import logging
+import warnings
 
 from matplotlib import ticker
 import matplotlib.pyplot as plt
@@ -93,12 +94,18 @@ def plot_phase(Z, amin=None, amax=None):
     Takes parameters amin, amax to scale the range of the amplitude. The phase
     is scaled to the range -pi to pi.
     """
+    amplitude, phase = np.abs(Z), np.angle(Z)
+    if np.any(amplitude == 0):
+        warnings.warn(
+            "This phase plot will be incorrect because "
+            "the phase of a zero-amplitude complex number is undefined. "
+            "Adding a small constant to the amplitude may help.")
     plt.figure(dpi=128)
     plt.subplot(1, 2, 1)
-    plt.imshow(np.abs(Z), vmin=amin, vmax=amax)
+    plt.imshow(amplitude, vmin=amin, vmax=amax)
     cb0 = plt.colorbar(orientation='horizontal')
     plt.subplot(1, 2, 2)
-    plt.imshow(np.angle(Z), vmin=-np.pi, vmax=np.pi, cmap=plt.cm.twilight)
+    plt.imshow(phase, vmin=-np.pi, vmax=np.pi, cmap=plt.cm.twilight)
     cb1 = plt.colorbar(orientation='horizontal')
     plt.show()
     print(np.min(Z), np.max(Z))


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Adds a warning to a plotting function that when the amplitude of a complex number is zero, then the phase will not be recovered correctly. This will cause the images to look discontinuous because zero amplitudes will render as having phase of PI or zero.