### PR TITLE
TST: Fix imaginary part of adjoint operator tests

### DIFF
--- a/tests/operators/test_convolution.py
+++ b/tests/operators/test_convolution.py
@@ -5,7 +5,7 @@ import unittest
 
 import numpy as np
 
-from .util import random_complex
+from .util import random_complex, inner_complex
 from tike.operators import Convolution
 
 __author__ = "Daniel Ching"
@@ -50,16 +50,16 @@ class TestConvolution(unittest.TestCase):
                 nearplane=nearplane,
                 scan=scan,
             )
-            a = np.sum(np.conj(o) * original)
-            b = np.sum(np.conj(d) * nearplane)
+            a = inner_complex(original, o)
+            b = inner_complex(d, nearplane)
             print()
-            print('<Q, P*Q> = {:.6f}{:+.6f}j'.format(
+            print('<Q , P*ψ> = {:.6f}{:+.6f}j'.format(
                 a.real.item(), a.imag.item()))
-            print('<N,  QP> = {:.6f}{:+.6f}j'.format(
+            print('<QP,   ψ> = {:.6f}{:+.6f}j'.format(
                 b.real.item(), b.imag.item()))
             # Test whether Adjoint fixed probe operator is correct
             np.testing.assert_allclose(a.real, b.real, rtol=1e-5)
-            # np.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
+            np.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/operators/test_convolution.py
+++ b/tests/operators/test_convolution.py
@@ -28,8 +28,8 @@ class TestConvolution(unittest.TestCase):
         np.random.seed(0)
         scan = np.random.rand(self.ntheta, self.nscan, 2) * 127 - 15
         original = random_complex(*self.original_shape)
-        nearplane = random_complex(self.ntheta, self.nscan,
-                                   self.probe_shape, self.probe_shape)
+        nearplane = random_complex(self.ntheta, self.nscan, self.probe_shape,
+                                   self.probe_shape)
 
         scan = scan.astype('float32')
         original = original.astype('complex64')
@@ -53,13 +53,14 @@ class TestConvolution(unittest.TestCase):
             a = inner_complex(original, o)
             b = inner_complex(d, nearplane)
             print()
-            print('<Q , P*ψ> = {:.6f}{:+.6f}j'.format(
-                a.real.item(), a.imag.item()))
-            print('<QP,   ψ> = {:.6f}{:+.6f}j'.format(
-                b.real.item(), b.imag.item()))
+            print('<Q , P*ψ> = {:.6f}{:+.6f}j'.format(a.real.item(),
+                                                      a.imag.item()))
+            print('<QP,   ψ> = {:.6f}{:+.6f}j'.format(b.real.item(),
+                                                      b.imag.item()))
             # Test whether Adjoint fixed probe operator is correct
             np.testing.assert_allclose(a.real, b.real, rtol=1e-5)
             np.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/operators/test_propagation.py
+++ b/tests/operators/test_propagation.py
@@ -25,10 +25,10 @@ class TestPropagation(unittest.TestCase):
     def test_adjoint(self):
         """Check that the adjoint operator is correct."""
         np.random.seed(0)
-        nearplane = random_complex(self.nwaves,
-                                   self.probe_shape, self.probe_shape)
-        farplane = random_complex(self.nwaves,
-                                  self.detector_shape, self.detector_shape)
+        nearplane = random_complex(self.nwaves, self.probe_shape,
+                                   self.probe_shape)
+        farplane = random_complex(self.nwaves, self.detector_shape,
+                                  self.detector_shape)
 
         nearplane = nearplane.astype('complex64')
         farplane = farplane.astype('complex64')
@@ -49,13 +49,14 @@ class TestPropagation(unittest.TestCase):
             a = inner_complex(nearplane, n)
             b = inner_complex(f, farplane)
             print()
-            print('<ψ , F*Ψ> = {:.6f}{:+.6f}j'.format(
-                a.real.item(), a.imag.item()))
-            print('<Fψ,   Ψ> = {:.6f}{:+.6f}j'.format(
-                b.real.item(), b.imag.item()))
+            print('<ψ , F*Ψ> = {:.6f}{:+.6f}j'.format(a.real.item(),
+                                                      a.imag.item()))
+            print('<Fψ,   Ψ> = {:.6f}{:+.6f}j'.format(b.real.item(),
+                                                      b.imag.item()))
             # Test whether Adjoint fixed probe operator is correct
             np.testing.assert_allclose(a.real, b.real, rtol=1e-5)
             np.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/operators/test_propagation.py
+++ b/tests/operators/test_propagation.py
@@ -5,7 +5,7 @@ import unittest
 
 import numpy as np
 
-from .util import random_complex
+from .util import random_complex, inner_complex
 from tike.operators import Propagation
 
 __author__ = "Daniel Ching"
@@ -46,16 +46,16 @@ class TestPropagation(unittest.TestCase):
                 nearplane=nearplane,
                 farplane=farplane,
             )
-            a = np.sum(np.conj(n) * nearplane)
-            b = np.sum(np.conj(f) * farplane)
+            a = inner_complex(nearplane, n)
+            b = inner_complex(f, farplane)
             print()
-            print('<N, F*D> = {:.6f}{:+.6f}j'.format(
+            print('<ψ , F*Ψ> = {:.6f}{:+.6f}j'.format(
                 a.real.item(), a.imag.item()))
-            print('<D,  FN> = {:.6f}{:+.6f}j'.format(
+            print('<Fψ,   Ψ> = {:.6f}{:+.6f}j'.format(
                 b.real.item(), b.imag.item()))
             # Test whether Adjoint fixed probe operator is correct
             np.testing.assert_allclose(a.real, b.real, rtol=1e-5)
-            # np.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
+            np.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/operators/test_ptycho.py
+++ b/tests/operators/test_ptycho.py
@@ -5,7 +5,7 @@ import unittest
 
 import numpy as np
 
-from .util import random_complex
+from .util import random_complex, inner_complex
 from tike.ptycho import PtychoBackend
 
 __author__ = "Daniel Ching"
@@ -16,7 +16,7 @@ __docformat__ = 'restructuredtext en'
 class TestPtycho(unittest.TestCase):
     """Test the ptychography operator."""
 
-    def setUp(self, ntheta=3, pw=15, nscan=53):
+    def setUp(self, ntheta=3, pw=15, nscan=27):
         """Load a dataset for reconstruction."""
         self.nscan = nscan
         self.ntheta = ntheta
@@ -61,21 +61,21 @@ class TestPtycho(unittest.TestCase):
                 scan=scan,
                 psi=original,
             )
-            a = np.sum(np.conj(d) * farplane)
-            b = np.sum(np.conj(p) * probe)
-            c = np.sum(np.conj(o) * original)
+            a = inner_complex(d, farplane)
+            b = inner_complex(probe, p)
+            c = inner_complex(original, o)
             print()
-            print('<FQP,     FQP> = {:.6f}{:+.6f}j'.format(
+            print('<FQP,     Ψ> = {:.6f}{:+.6f}j'.format(
                 a.real.item(), a.imag.item()))
-            print('<P  , Q*F*FQP> = {:.6f}{:+.6f}j'.format(
+            print('<P  , Q*F*Ψ> = {:.6f}{:+.6f}j'.format(
                 b.real.item(), b.imag.item()))
-            print('<Q  , P*F*FPQ> = {:.6f}{:+.6f}j'.format(
+            print('<Q  , P*F*Ψ> = {:.6f}{:+.6f}j'.format(
                 c.real.item(), c.imag.item()))
             # Test whether Adjoint fixed probe operator is correct
             np.testing.assert_allclose(a.real, b.real, rtol=1e-5)
-            # np.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
+            np.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
             np.testing.assert_allclose(a.real, c.real, rtol=1e-5)
-            # np.testing.assert_allclose(a.imag, c.imag, rtol=1e-5)
+            np.testing.assert_allclose(a.imag, c.imag, rtol=1e-5)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/operators/test_ptycho.py
+++ b/tests/operators/test_ptycho.py
@@ -31,8 +31,7 @@ class TestPtycho(unittest.TestCase):
         scan = np.random.rand(*self.scan_shape).astype('float32') * 127 - 15
         probe = random_complex(*self.probe_shape)
         original = random_complex(*self.original_shape)
-        farplane = random_complex(self.ntheta, self.nscan,
-                                  *self.detector_shape)
+        farplane = random_complex(self.ntheta, self.nscan, *self.detector_shape)
 
         probe = probe.astype('complex64')
         original = original.astype('complex64')
@@ -76,6 +75,7 @@ class TestPtycho(unittest.TestCase):
             np.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
             np.testing.assert_allclose(a.real, c.real, rtol=1e-5)
             np.testing.assert_allclose(a.imag, c.imag, rtol=1e-5)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/operators/util.py
+++ b/tests/operators/util.py
@@ -1,10 +1,10 @@
-
 import numpy as np
+
 
 def random_complex(*args):
     """Return a complex random array in the range (-0.5, 0.5)."""
-    return (        np.random.rand(*args) - 0.5
-            + 1j * (np.random.rand(*args) - 0.5))
+    return (np.random.rand(*args) - 0.5 + 1j * (np.random.rand(*args) - 0.5))
+
 
 def inner_complex(x, y):
     """Return the complex inner product; the order of the operands matters."""

--- a/tests/operators/util.py
+++ b/tests/operators/util.py
@@ -5,3 +5,7 @@ def random_complex(*args):
     """Return a complex random array in the range (-0.5, 0.5)."""
     return (        np.random.rand(*args) - 0.5
             + 1j * (np.random.rand(*args) - 0.5))
+
+def inner_complex(x, y):
+    """Return the complex inner product; the order of the operands matters."""
+    return np.sum(np.conj(x) * y)


### PR DESCRIPTION
This basically fixes some broken (deactivated tests) where the imaginary part of the adjoint tests was wrong because I wasn't using the correct order of the arguments for the inner product.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [x] Write tests for new functions or explain why they are not needed.
- [x] Build the documentation successfully
- [x] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
