### PR TITLE
BUG: Must call __enter__ for composed classes

### DIFF
--- a/src/tike/operators/ptycho.py
+++ b/src/tike/operators/ptycho.py
@@ -75,6 +75,11 @@ class Ptycho(Operator):
         self.cost = getattr(self, f'_{model}_cost')
         self.grad = getattr(self, f'_{model}_grad')
 
+    def __enter__(self):
+        self.propagation.__enter__()
+        self.diffraction.__enter__()
+        return self
+
     def __exit__(self, type, value, traceback):
         self.propagation.__exit__(type, value, traceback)
         self.diffraction.__exit__(type, value, traceback)


### PR DESCRIPTION
When composing a context manager from other context managers
we must also call __enter__ for the composed classes.