### PR TITLE
NEW: Use properties of linear operators to speed up linesearch

### DIFF
--- a/src/tike/opt.py
+++ b/src/tike/opt.py
@@ -166,5 +166,5 @@ def conjugate_gradient(
             d=dir,
         )
         x = x + gamma * dir
-        logger.debug("%4d, %.3e, %.7e", (i + 1), gamma, cost)
+        logger.debug("step %d; length = %.3e; cost = %.6e", i, gamma, cost)
     return x, cost

--- a/src/tike/opt.py
+++ b/src/tike/opt.py
@@ -50,7 +50,7 @@ def line_search(f, x, d, step_length=1, step_shrink=0.5, linear=None):
 
     """
     assert step_shrink > 0 and step_shrink < 1
-    linear = lambda x: x if linear is None else linear
+    linear = (lambda x: x) if linear is None else linear
     m = 0  # Some tuning parameter for termination
     # Save cache function calls instead of computing them many times
     lx = linear(x)

--- a/src/tike/opt.py
+++ b/src/tike/opt.py
@@ -12,7 +12,34 @@ import warnings
 
 logger = logging.getLogger(__name__)
 
-
+def line_search_sqr(f, p1, p2, p3, step_length=1, step_shrink=0.5):
+        """Optimized line search for square functions
+            Example of otimized computation for the Gaussian model:
+            sum_j|G_j(psi+gamma dpsi)|^2 = sum_j|G_j(psi)|^2+
+                                           gamma^2*sum_j|G_j(dpsi)|^2+
+                                           gamma*sum_j (G_j(psi).real*G_j(psi).real+2*G_j(dpsi).imag*G_j(dpsi).imag)
+            p1 = sum_j|G_j(psi)|^2
+            p2 = sum_j|G_j(dpsi)|^2
+            p3 = sum_j (G_j(psi).real*G_j(psi).real+2*G_j(dpsi).imag*G_j(dpsi).imag)
+            Parameters	
+            ----------	
+            f : function(x)	
+                The function being optimized.	
+            p1,p2,p3 : vectors	
+                Temporarily vectors to avoid computing forward operators        
+        """
+        
+        assert step_shrink > 0 and step_shrink < 1
+        m = 0  # Some tuning parameter for termination
+        fp1 = f(p1) # optimize computation
+        # Decrease the step length while the step increases the cost function
+        while f(p1+step_length**2 * p2+step_length*p3) > fp1 + step_shrink * m:
+            if step_length < 1e-32:
+                warnings.warn("Line search failed for conjugate gradient.")
+                return 0
+            step_length *= step_shrink            
+        return step_length
+    
 def line_search(f, x, d, step_length=1, step_shrink=0.5, linear=None):
     """Perform a backtracking line search for a partially-linear cost-function.
 


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Related to #60. In this PR, I'm trying to reduce the time spent on the backtracking line search in exchange for memory.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Our Operators are linear operators e.g. `F(a + c * b) = F(a) + c * F(b)` where c is a scalar, so we can speed up the line search by caching `F(x)` and `F(d)` where `d` is the search direction and `F()` is the function being minimized.

### General

This might work quite well if the ptychography cost functions easily split into linear and non-linear parts. The cost function for a single mode could be broken this way:

```python
def nonlinear(x):
    return gaussian_cost(data, np.square(np.abs(x)))

def linear(x, ...):
    return fwd(x, ...)
```

However, when we have probe with multiple-incoherent modes, then life becomes difficult. :cry: 

```python
def nonlinear(x, ...):
    intensity = 0
    for mode in modes:
        intensity += np.square(np.abs(fwd(x, mode, ...)))    
    return gaussian_cost(data, intensity)

def linear(x):
    return x
```

### Ptycho-specific

We could write a specific line searcher for ptychography by refactoring the intensity sum as follows:

```python 
= sum(square(abs(a + cb)))
= sum((a + cb) * conj(a + cb))
= sum(square(abs(a))) + c**2 * sum(square(abs(b))) + sum(c * (conj(a) * b + a * conj(b)))
```
where  `a = fwd(x)`, `b = fwd(d)`, and `c = step`. This allows us to cache three arrays and change the step size without calling the forward operator every time. I guess this is fine because the code is modular.

## Pre-Merge Checklists

### Submitter
- [ ] Write a helpfully descriptive pull request title.
- [ ] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Build the documentation successfully
- [ ] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
