### PR TITLE
STY: Add clang-format and format .cu files

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+AlwaysBreakAfterReturnType: All
+BreakBeforeBinaryOperators: All


### PR DESCRIPTION
This is just one commit to add a clang-format file to the repository so that CUDA kernels are formatted consistently.