### PR TITLE
Remove nscan param to prepare for multi-GPU

### DIFF
--- a/src/tike/operators/cupy/convolution.cu
+++ b/src/tike/operators/cupy/convolution.cu
@@ -7,9 +7,9 @@
 // Padding areas are untouched and retain whatever values they had before the
 // kernel was launched.
 
-// The kernel should be launched with the following config:
-// block shape = (min(max_thread, patch_size**2), 0, 0)
-// grid shape = (-(-patch_size**2 // max_thread), nscan, nimage)
+// The kernel should be launched with the following maximum shapes:
+// grid shape = (patch_size, nscan, nimage)
+// block shape = (min(max_thread, patch_size), 1, 1)
 
 // images has shape (nimage, nimagey, nimagex)
 // patches has shape (nscan, patch_shape, patch_shape)
@@ -19,60 +19,66 @@ extern "C" __global__ void
 patch(float2 *images, float2 *patches, const float2 *scan, int nimage,
       int nimagey, int nimagex, int nscan, int patch_shape, int padded_shape,
       bool forward) {
-  const int tp = threadIdx.x + blockDim.x * (blockIdx.x);  // thread patch
-  const int ts = blockIdx.y;                               // thread scan
-  const int ti = blockIdx.z;                               // thread image
-  if (tp >= patch_shape * patch_shape || ts >= nscan || ti >= nimage) return;
-
-  // patch index (pi)
-  const int px = tp % patch_shape;
-  const int py = tp / patch_shape;
   const int pad = (padded_shape - patch_shape) / 2;
-  // clang-format off
-  const int pi = (
-    + pad + px + padded_shape * (pad + py)
-    + padded_shape * padded_shape * (ts + nscan * ti)
-  );
-  // clang-format on
 
-  const float sx = floor(scan[ts + ti * nscan].y);
-  const float sy = floor(scan[ts + ti * nscan].x);
+  // for each image
+  for (int ti = blockIdx.z; ti < nimage; ti += gridDim.z) {
+    // for each scan position
+    for (int ts = blockIdx.y; ts < nscan; ts += gridDim.y) {
+      // x,y scan coordinates in image
+      const float sx = floor(scan[ts + ti * nscan].y);
+      const float sy = floor(scan[ts + ti * nscan].x);
 
-  if (sx < 0 || nimagex <= sx + patch_shape || sy < 0
-      || nimagey <= sy + patch_shape) {
-    // printf("%f, %f - %f, %f\n", sx, sy, sxf, syf);
-    assert(false);
-    return;
-  }
+      if (sx < 0 || nimagex <= sx + patch_shape || sy < 0
+          || nimagey <= sy + patch_shape) {
+        // printf("%f, %f - %f, %f\n", sx, sy, sxf, syf);
+        assert(false);
+        return;
+      }
 
-  // image index (ii)
-  const int ii = sx + px + nimagex * (sy + py + nimagey * ti);
+      // for x,y coords in patch
+      for (int py = blockIdx.x; py < patch_shape; py += gridDim.x) {
+        for (int px = threadIdx.x; px < patch_shape; px += blockDim.x) {
+          // linear patch index (pi)
+          // clang-format off
+          const int pi = (
+            + pad + px + padded_shape * (pad + py)
+            + padded_shape * padded_shape * (ts + nscan * ti)
+          );
+          // clang-format on
 
-  const float sxf = scan[ts + ti * nscan].y - sx;
-  const float syf = scan[ts + ti * nscan].x - sy;
-  assert(1.0f >= sxf && sxf >= 0.0f && 1.0f >= syf && syf >= 0.0f);
+          // image index (ii)
+          const int ii = sx + px + nimagex * (sy + py + nimagey * ti);
 
-  // Linear interpolation
-  // clang-format off
-  if (forward) {
-    patches[pi].x = images[ii              ].x * (1.0f - sxf) * (1.0f - syf)
-                  + images[ii + 1          ].x * (       sxf) * (1.0f - syf)
-                  + images[ii     + nimagex].x * (1.0f - sxf) * (       syf)
-                  + images[ii + 1 + nimagex].x * (       sxf) * (       syf);
+          const float sxf = scan[ts + ti * nscan].y - sx;
+          const float syf = scan[ts + ti * nscan].x - sy;
+          assert(1.0f >= sxf && sxf >= 0.0f && 1.0f >= syf && syf >= 0.0f);
 
-    patches[pi].y = images[ii              ].y * (1.0f - sxf) * (1.0f - syf)
-                  + images[ii + 1          ].y * (       sxf) * (1.0f - syf)
-                  + images[ii     + nimagex].y * (1.0f - sxf) * (       syf)
-                  + images[ii + 1 + nimagex].y * (       sxf) * (       syf);
-  } else {
-    const float2 tmp = patches[pi];
-    atomicAdd(&images[ii              ].x, tmp.x * (1.0f - sxf) * (1.0f - syf));
-    atomicAdd(&images[ii              ].y, tmp.y * (1.0f - sxf) * (1.0f - syf));
-    atomicAdd(&images[ii + 1          ].y, tmp.y * (       sxf) * (1.0f - syf));
-    atomicAdd(&images[ii + 1          ].x, tmp.x * (       sxf) * (1.0f - syf));
-    atomicAdd(&images[ii     + nimagex].x, tmp.x * (1.0f - sxf) * (       syf));
-    atomicAdd(&images[ii     + nimagex].y, tmp.y * (1.0f - sxf) * (       syf));
-    atomicAdd(&images[ii + 1 + nimagex].x, tmp.x * (       sxf) * (       syf));
-    atomicAdd(&images[ii + 1 + nimagex].y, tmp.y * (       sxf) * (       syf));
+          // Linear interpolation
+          // clang-format off
+          if (forward) {
+            patches[pi].x = images[ii              ].x * (1.0f - sxf) * (1.0f - syf)
+                          + images[ii + 1          ].x * (       sxf) * (1.0f - syf)
+                          + images[ii     + nimagex].x * (1.0f - sxf) * (       syf)
+                          + images[ii + 1 + nimagex].x * (       sxf) * (       syf);
+
+            patches[pi].y = images[ii              ].y * (1.0f - sxf) * (1.0f - syf)
+                          + images[ii + 1          ].y * (       sxf) * (1.0f - syf)
+                          + images[ii     + nimagex].y * (1.0f - sxf) * (       syf)
+                          + images[ii + 1 + nimagex].y * (       sxf) * (       syf);
+          } else {
+            const float2 tmp = patches[pi];
+            atomicAdd(&images[ii              ].x, tmp.x * (1.0f - sxf) * (1.0f - syf));
+            atomicAdd(&images[ii              ].y, tmp.y * (1.0f - sxf) * (1.0f - syf));
+            atomicAdd(&images[ii + 1          ].y, tmp.y * (       sxf) * (1.0f - syf));
+            atomicAdd(&images[ii + 1          ].x, tmp.x * (       sxf) * (1.0f - syf));
+            atomicAdd(&images[ii     + nimagex].x, tmp.x * (1.0f - sxf) * (       syf));
+            atomicAdd(&images[ii     + nimagex].y, tmp.y * (1.0f - sxf) * (       syf));
+            atomicAdd(&images[ii + 1 + nimagex].x, tmp.x * (       sxf) * (       syf));
+            atomicAdd(&images[ii + 1 + nimagex].y, tmp.y * (       sxf) * (       syf));
+          }
+        }
+      }
+    }
   }
 }

--- a/src/tike/operators/cupy/convolution.py
+++ b/src/tike/operators/cupy/convolution.py
@@ -10,74 +10,29 @@ _patch_kernel = cp.RawKernel(_cu_source, "patch")
 
 
 class Convolution(Operator, numpy.Convolution):
+
     def __enter__(self):
         max_thread = min(self.probe_shape**2,
                          _patch_kernel.attributes['max_threads_per_block'])
-        self.blocks = (max_thread, )
+        self.blocks = (max_thread,)
         self.grids = (
             -(-self.probe_shape**2 // max_thread),  # ceil division
             self.nscan,
             self.ntheta,
         )
-        self.pad = (self.detector_shape - self.probe_shape) // 2
-        self.end = self.probe_shape + self.pad
         return self
 
     def __exit__(self, type, value, traceback):
         pass
 
-    def fwd(self, psi, scan, probe):
-        """Extract probe shaped patches from the psi at each scan position.
-
-        The patches within the bounds of psi are linearly interpolated, and
-        indices outside the bounds of psi are not allowed.
-        """
-        psi = psi.reshape(self.ntheta, self.nz, self.n)
-        self._check_shape_probe(probe)
-        patches = cp.zeros(
-            (self.ntheta, self.nscan // self.fly, self.fly, 1,
-             self.detector_shape, self.detector_shape),
-            dtype='complex64',
-        )
+    def _patch(self, patches, psi, scan, fwd=True):
         _patch_kernel(
             self.grids,
             self.blocks,
             (psi, patches, scan, self.ntheta, self.nz, self.n, self.nscan,
-             self.probe_shape, self.detector_shape, True),
+             self.probe_shape, patches.shape[-1], fwd),
         )
-        patches[..., self.pad:self.end, self.pad:self.end] *= probe
-        return patches
-
-    def adj(self, nearplane, scan, probe, obj=None, overwrite=False):
-        """Combine probe shaped patches into a psi shaped grid by addition."""
-        self._check_shape_nearplane(nearplane)
-        self._check_shape_probe(probe)
-        if not overwrite:
-            nearplane = nearplane.copy()
-        nearplane[..., self.pad:self.end, self.pad:self.end] *= cp.conj(probe)
-        if obj is None:
-            obj = cp.zeros((self.ntheta, self.nz, self.n), dtype='complex64')
-        _patch_kernel(
-            self.grids,
-            self.blocks,
-            (obj, nearplane, scan, self.ntheta, self.nz, self.n, self.nscan,
-             self.probe_shape, self.detector_shape, False),
-        )
-        return obj
-
-    def adj_probe(self, nearplane, scan, psi, overwrite=False):
-        """Combine probe shaped patches into a probe."""
-        self._check_shape_nearplane(nearplane)
-        patches = cp.empty(
-            (self.ntheta, self.nscan // self.fly, self.fly, 1,
-             self.probe_shape, self.probe_shape),
-            dtype='complex64',
-        )
-        _patch_kernel(
-            self.grids,
-            self.blocks,
-            (psi, patches, scan, self.ntheta, self.nz, self.n, self.nscan,
-             self.probe_shape, self.probe_shape, True),
-        )
-        return (nearplane[..., self.pad:self.end, self.pad:self.end] *
-                cp.conj(patches))
+        if fwd:
+            return patches
+        else:
+            return psi

--- a/src/tike/operators/cupy/convolution.py
+++ b/src/tike/operators/cupy/convolution.py
@@ -18,14 +18,14 @@ class Convolution(Operator, numpy.Convolution):
         pass
 
     def _patch(self, patches, psi, scan, fwd=True):
-        max_thread = min(self.probe_shape**2,
+        max_thread = min(self.probe_shape,
                          _patch_kernel.attributes['max_threads_per_block'])
-        blocks = (max_thread,)
         grids = (
-            -(-self.probe_shape**2 // max_thread),  # ceil division
+            self.probe_shape,
             scan.shape[-2],
             self.ntheta,
         )
+        blocks = (max_thread,)
         _patch_kernel(
             grids,
             blocks,

--- a/src/tike/operators/cupy/propagation.py
+++ b/src/tike/operators/cupy/propagation.py
@@ -10,48 +10,15 @@ class Propagation(Operator, numpy.Propagation):
     """A Fourier-based free-space propagation using CuPy."""
 
     def __enter__(self):
-        farplane = cp.empty(
-            (self.nwaves, self.detector_shape, self.detector_shape),
-            dtype='complex64')
-        self.plan = get_fft_plan(farplane, axes=(-2, -1))
-        del farplane
+        # TODO: initialize fftplan cache
         return self
 
     def __exit__(self, type, value, traceback):
-        del self.plan
+        # TODO: delete fftplan cache
         pass
 
-    def fwd(self, nearplane, overwrite=False, **kwargs):
-        self._check_shape(nearplane)
-        if not overwrite:
-            nearplane = cp.copy(nearplane)
-        shape = nearplane.shape
-        with self.plan:
-            return fftn(
-                nearplane.reshape(self.nwaves, self.detector_shape,
-                                  self.detector_shape),
-                norm='ortho',
-                axes=(-2, -1),
-                overwrite_x=True,
-            ).reshape(shape)
+    def _fft2(self, *args, overwrite=False, **kwargs):
+        return fftn(*args, overwrite_x=overwrite, **kwargs)
 
-    def adj(self, farplane, overwrite=False, **kwargs):
-        self._check_shape(farplane)
-        if not overwrite:
-            farplane = cp.copy(farplane)
-        shape = farplane.shape
-        with self.plan:
-            return ifftn(
-                farplane.reshape(self.nwaves, self.detector_shape,
-                                 self.detector_shape),
-                norm='ortho',
-                axes=(-2, -1),
-                overwrite_x=True,
-            ).reshape(shape)
-
-    def _check_shape(self, x):
-        assert type(x) is cp.ndarray, type(x)
-        shape = (self.nwaves, self.detector_shape, self.detector_shape)
-        if (__debug__ and x.shape[-2:] != shape[-2:]
-                and cp.prod(x.shape[:-2]) != self.nwaves):
-            raise ValueError(f'waves must have shape {shape} not {x.shape}.')
+    def _ifft2(self, *args, overwrite=False, **kwargs):
+        return ifftn(*args, overwrite_x=overwrite, **kwargs)

--- a/src/tike/operators/numpy/convolution.py
+++ b/src/tike/operators/numpy/convolution.py
@@ -63,12 +63,14 @@ class Convolution(Operator):
         psi = psi.reshape(self.ntheta, self.nz, self.n)
         self._check_shape_probe(probe, scan.shape[-2])
         patches = self.xp.zeros(
-            (self.ntheta, scan.shape[-2], self.detector_shape, self.detector_shape),
+            (self.ntheta, scan.shape[-2], self.detector_shape,
+             self.detector_shape),
             dtype='complex64',
         )
         patches = self._patch(patches, psi, scan, fwd=True)
-        patches = patches.reshape(self.ntheta, scan.shape[-2] // self.fly, self.fly,
-                                  1, self.detector_shape, self.detector_shape)
+        patches = patches.reshape(self.ntheta, scan.shape[-2] // self.fly,
+                                  self.fly, 1, self.detector_shape,
+                                  self.detector_shape)
         patches[..., self.pad:self.end, self.pad:self.end] *= probe
         return patches
 
@@ -94,8 +96,9 @@ class Convolution(Operator):
             dtype='complex64',
         )
         patches = self._patch(patches, psi, scan, fwd=True)
-        patches = patches.reshape(self.ntheta, scan.shape[-2] // self.fly, self.fly,
-                                  1, self.probe_shape, self.probe_shape)
+        patches = patches.reshape(self.ntheta, scan.shape[-2] // self.fly,
+                                  self.fly, 1, self.probe_shape,
+                                  self.probe_shape)
         patches = patches.conj()
         patches *= nearplane[..., self.pad:self.end, self.pad:self.end]
         return patches
@@ -104,8 +107,8 @@ class Convolution(Operator):
         """Check that the probe is correctly shaped."""
         assert type(x) is self.xp.ndarray, type(x)
         # unique probe for each position
-        shape1 = (self.ntheta, nscan // self.fly, self.fly, 1,
-                  self.probe_shape, self.probe_shape)
+        shape1 = (self.ntheta, nscan // self.fly, self.fly, 1, self.probe_shape,
+                  self.probe_shape)
         # one probe for all positions
         shape2 = (self.ntheta, 1, 1, 1, self.probe_shape, self.probe_shape)
         if __debug__ and x.shape != shape2 and x.shape != shape1:

--- a/src/tike/operators/numpy/convolution.py
+++ b/src/tike/operators/numpy/convolution.py
@@ -16,8 +16,6 @@ class Convolution(Operator):
         The number of scan positions at each angular view.
     fly : int
         The number of consecutive scan positions that describe a fly scan.
-    nmode : int
-        The number of probe modes per scan position.
     probe_shape : int
         The pixel width and height of the (square) probe illumination.
     nz, n : int
@@ -30,10 +28,10 @@ class Convolution(Operator):
     psi : (ntheta, nz, n) complex64
         The complex wavefront modulation of the object.
     probe : complex64
-        The (ntheta, nscan // fly, fly, nmode, probe_shape, probe_shape)
+        The (ntheta, nscan // fly, fly, 1, probe_shape, probe_shape)
         complex illumination function.
     nearplane: complex64
-        The (ntheta, nscan // fly, fly, nmode, probe_shape, probe_shape)
+        The (ntheta, nscan // fly, fly, 1, probe_shape, probe_shape)
         wavefronts after exiting the object.
     scan : (ntheta, nscan, 2) float32
         Coordinates of the minimum corner of the probe grid for each
@@ -42,14 +40,13 @@ class Convolution(Operator):
 
     """
 
-    def __init__(self, probe_shape, nscan, nz, n, ntheta, nmode=1, fly=1,
+    def __init__(self, probe_shape, nscan, nz, n, ntheta, fly=1,
                  detector_shape=None, **kwargs):  # yapf: disable
         self.probe_shape = probe_shape
         self.nscan = nscan
         self.nz = nz
         self.n = n
         self.ntheta = ntheta
-        self.nmode = nmode
         self.fly = fly
         if detector_shape is None:
             self.detector_shape = probe_shape

--- a/src/tike/operators/numpy/propagation.py
+++ b/src/tike/operators/numpy/propagation.py
@@ -1,7 +1,7 @@
 """Defines a free-space propagation operator based on the NumPy FFT module."""
 
 import numpy as np
-from numpy.fft import fftn, ifftn
+from numpy.fft import fft2, ifft2
 
 from .operator import Operator
 
@@ -9,18 +9,13 @@ from .operator import Operator
 class Propagation(Operator):
     """A base class for Fourier-based free-space propagation.
 
-    Take an (..., N, N) array and pads the last two dimensions with zeros until
-    it is size (..., M, M). Then apply the Fourier transform to the last two
+    Take an (..., N, N) array and apply the Fourier transform to the last two
     dimensions.
 
     Attributes
     ----------
-    probe_shape : int
-        The pixel width and height of the nearplane waves.
     detector_shape : int
-        The pixel width and height of the farplane waves.
-    nwaves : int
-        The number of waves to propagate from the nearplane to farplane.
+        The pixel width and height of the nearplane and farplane waves.
     model : string
         The type of noise model to use for the cost functions.
     cost : (data-like, farplane-like) -> float
@@ -30,57 +25,57 @@ class Propagation(Operator):
 
     Parameters
     ----------
-    nearplane: (..., probe_shape, probe_shape) complex64
+    nearplane: (..., detector_shape, detector_shape) complex64
         The wavefronts after exiting the object.
     farplane: (..., detector_shape, detector_shape) complex64
         The wavefronts hitting the detector respectively.
-    data : (ntheta, nscan, detector_shape, detector_shape) complex64
+        Shape for cost functions and gradients is
+        (ntheta, nscan // fly, fly, 1, detector_shape, detector_shape).
+    data, intensity : (ntheta, nscan, detector_shape, detector_shape) complex64
         data is the square of the absolute value of `farplane`. `data` is the
         intensity of the `farplane`.
 
     """
 
-    def __init__(self, nwaves, detector_shape, probe_shape, model='gaussian',
-                 **kwargs):  # yapf: disable
-        self.nwaves = nwaves
-        self.probe_shape = probe_shape
+    def __init__(self, detector_shape, model='gaussian', **kwargs):
         self.detector_shape = detector_shape
         self.cost = getattr(self, f'_{model}_cost')
         self.grad = getattr(self, f'_{model}_grad')
 
+    def _fft2(self, *args, overwrite=False, **kwargs):
+        """Reimplement this wrapper to switch out the FFT library"""
+        return fft2(*args, **kwargs).astype('complex64')
+
+    def _ifft2(self, *args, overwrite=False, **kwargs):
+        """Reimplement this wrapper to switch out the FFT library"""
+        return ifft2(*args, **kwargs).astype('complex64')
+
     def fwd(self, nearplane, overwrite=False, **kwargs):
         """Forward Fourier-based free-space propagation operator."""
         self._check_shape(nearplane)
-        if not overwrite:
-            nearplane = np.copy(nearplane)
         shape = nearplane.shape
-        return fftn(
-            nearplane.reshape(self.nwaves, self.detector_shape,
-                              self.detector_shape),
+        return self._fft2(
+            nearplane.reshape(-1, self.detector_shape, self.detector_shape),
             norm='ortho',
             axes=(-2, -1),
-            # overwrite_x=True,
-        ).reshape(shape).astype('complex64')
+            overwrite=overwrite,
+        ).reshape(shape)
 
     def adj(self, farplane, overwrite=False, **kwargs):
         """Adjoint Fourier-based free-space propagation operator."""
         self._check_shape(farplane)
-        if not overwrite:
-            farplane = np.copy(farplane)
         shape = farplane.shape
-        return ifftn(
-            farplane.reshape(self.nwaves, self.detector_shape,
-                             self.detector_shape),
+        return self._ifft2(
+            farplane.reshape(-1, self.detector_shape, self.detector_shape),
             norm='ortho',
             axes=(-2, -1),
-            # overwrite_x=True,
-        ).reshape(shape).astype('complex64')
+            overwrite=overwrite,
+        ).reshape(shape)
 
     def _check_shape(self, x):
         assert type(x) is self.xp.ndarray, type(x)
-        shape = (self.nwaves, self.detector_shape, self.detector_shape)
-        if (__debug__ and x.shape[-2:] != shape[-2:]
-                and np.prod(x.shape[:-2]) != self.nwaves):
+        shape = (-1, self.detector_shape, self.detector_shape)
+        if (__debug__ and x.shape[-2:] != shape[-2:]):
             raise ValueError(f'waves must have shape {shape} not {x.shape}.')
 
     # COST FUNCTIONS AND GRADIENTS --------------------------------------------

--- a/src/tike/operators/numpy/ptycho.py
+++ b/src/tike/operators/numpy/ptycho.py
@@ -20,8 +20,6 @@ class Ptycho(Operator):
         The number of scan positions at each angular view.
     fly : int
         The number of consecutive scan positions that describe a fly scan.
-    nmode : int
-        The number of probe modes per scan position.
     probe_shape : int
         The pixel width and height of the (square) probe illumination.
     detector_shape : int
@@ -42,7 +40,7 @@ class Ptycho(Operator):
     psi : (ntheta, nz, n) complex64
         The complex wavefront modulation of the object.
     probe : complex64
-        The complex (ntheta, nscan // fly, fly, nmode, probe_shape,
+        The complex (ntheta, nscan // fly, fly, 1, probe_shape,
         probe_shape) illumination function.
     mode : complex64
         A single (ntheta, nscan // fly, fly, 1, probe_shape, probe_shape)

--- a/src/tike/operators/numpy/ptycho.py
+++ b/src/tike/operators/numpy/ptycho.py
@@ -67,11 +67,8 @@ class Ptycho(Operator):
                  **kwargs):  # noqa: D102 yapf: disable
         """Please see help(Ptycho) for more info."""
         self.propagation = propagation(
-            nwaves=ntheta * nscan,
-            probe_shape=probe_shape,
             detector_shape=detector_shape,
             model=model,
-            fly=fly,
             **kwargs,
         )
         self.diffraction = diffraction(

--- a/src/tike/operators/numpy/ptycho.py
+++ b/src/tike/operators/numpy/ptycho.py
@@ -72,7 +72,6 @@ class Ptycho(Operator):
         self.diffraction = diffraction(
             probe_shape=probe_shape,
             detector_shape=detector_shape,
-            nscan=nscan,
             nz=nz,
             n=n,
             ntheta=ntheta,
@@ -81,7 +80,6 @@ class Ptycho(Operator):
             **kwargs,
         )
         # TODO: Replace these with @property functions
-        self.nscan = nscan
         self.probe_shape = probe_shape
         self.detector_shape = detector_shape
         self.nz = nz

--- a/src/tike/operators/numpy/ptycho.py
+++ b/src/tike/operators/numpy/ptycho.py
@@ -58,7 +58,7 @@ class Ptycho(Operator):
 
     """
 
-    def __init__(self, detector_shape, probe_shape, nscan, nz, n,
+    def __init__(self, detector_shape, probe_shape, nz, n,
                  ntheta=1, model='gaussian', fly=1,
                  propagation=Propagation,
                  diffraction=Convolution,

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -109,7 +109,6 @@ def simulate(
     assert psi.ndim == 3
     check_allowed_positions(scan, psi, probe)
     with Ptycho(
-            nscan=scan.shape[-2],
             probe_shape=probe.shape[-1],
             detector_shape=int(detector_shape),
             nz=psi.shape[-2],
@@ -128,7 +127,7 @@ def simulate(
             data += np.square(
                 np.linalg.norm(
                     farplane.reshape(operator.ntheta,
-                                     operator.nscan // operator.fly, -1,
+                                     scan.shape[-2] // operator.fly, -1,
                                      detector_shape, detector_shape),
                     ord=2,
                     axis=2,
@@ -157,7 +156,6 @@ def reconstruct(
     if algorithm in solvers.__all__:
         # Initialize an operator.
         with Ptycho(
-                nscan=scan.shape[1],
                 probe_shape=probe.shape[-1],
                 detector_shape=data.shape[-1],
                 nz=psi.shape[-2],


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Currently, if the number of scan positions is not a multiple of the number of GPUs, we must keep track of two Ptycho operators. There are three solutions to this problem:

1. Keep `nscan`; track multiple Ptycho operators. I think this is not a good option.
2. Remove the `nscan` parameter from the Ptycho operator. It will simplify the implementation of multi-GPU workloads by letting multiple-GPUs share the same Ptycho operator. @xiaodong-yu  suggested this solution.
3. Keep `nscan`; restrict or pad the number of scan positions so that it is always multiple of the number of GPUs.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
This PR takes the second approach. The `nscan` parameter has been purged from the operators. It is no longer used when passed as an argument in the constructors. Instead, this parameter is pulled from the shape of the `scan` array passed during function calls. In order to keep the benefits of FFT plan caching. The cache now uses a dictionary to store multiple FFT plans. I expect that the number of FFT plans should not exceed 2, so we shouldn't have to worry about the memory cost at this time.

I also used this opportunity to refactor the Propagation and Convolution operators so that the amount of shared code between the NumPy and CuPy operators is increased.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [x] Write tests for new functions or explain why they are not needed.
- [ ] Build the documentation successfully
- [x] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
