### PR TITLE
TST: Use pytest.skip() instead of manually selecting files

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -38,9 +38,7 @@ test:
   source_files:
     - tests/*
   commands:
-    - pytest tests/operators/
-    - pytest tests/test_ptycho.py
-    - pytest tests/test_lamino.py
+    - pytest tests/
 
 app:
     own_environment: True

--- a/tests/operators/test_lamino.py
+++ b/tests/operators/test_lamino.py
@@ -47,6 +47,7 @@ class TestLamino(unittest.TestCase):
             assert obj.shape == o.shape
             a = inner_complex(d, data)
             b = inner_complex(obj, o)
+            print()
             print('<Lobj,   data> = {:.6f}{:+.6f}j'.format(
                 a.real.item(), a.imag.item()))
             print('<obj  , L*data> = {:.6f}{:+.6f}j'.format(

--- a/tests/test_communicator.py
+++ b/tests/test_communicator.py
@@ -1,8 +1,9 @@
 import numpy as np
-from tike.communicator import MPICommunicator
+# from tike.communicator import MPICommunicator
 import unittest
+import pytest
 
-
+@pytest.mark.skip(reason="The communicator module is broken/disabled.")
 class TestMPICommunicator(unittest.TestCase):
     """Test the functions of the MPICommunicator class."""
 

--- a/tests/test_communicator.py
+++ b/tests/test_communicator.py
@@ -3,6 +3,7 @@ import numpy as np
 import unittest
 import pytest
 
+
 @pytest.mark.skip(reason="The communicator module is broken/disabled.")
 class TestMPICommunicator(unittest.TestCase):
     """Test the functions of the MPICommunicator class."""
@@ -19,7 +20,7 @@ class TestMPICommunicator(unittest.TestCase):
         # print("{} ptycho_data:\n{}".format(comm.rank, ptycho_data))
         lo = comm.rank * 3
         np.testing.assert_array_equal(ptycho_data[:, 0:3, :],
-                                      ptycho_data[:, lo:lo+3, :])
+                                      ptycho_data[:, lo:lo + 3, :])
         # Assert the reverse transform works
         tomo_data1 = comm.get_tomo_slice(ptycho_data)
         np.testing.assert_array_equal(tomo_data, tomo_data1)

--- a/tests/test_tomo.py
+++ b/tests/test_tomo.py
@@ -50,7 +50,8 @@ import lzma
 import numpy as np
 import os
 import pickle
-import tike.tomo
+# import tike.tomo
+import pytest
 import unittest
 
 __author__ = "Daniel Ching"
@@ -59,7 +60,7 @@ __docformat__ = 'restructuredtext en'
 
 testdir = os.path.dirname(__file__)
 
-
+@pytest.mark.skip(reason="The tomo module is broken/disabled.")
 class TestPtychoRecon(unittest.TestCase):
     """Test various ptychography reconstruction methods for consistency."""
 

--- a/tests/test_tomo.py
+++ b/tests/test_tomo.py
@@ -60,6 +60,7 @@ __docformat__ = 'restructuredtext en'
 
 testdir = os.path.dirname(__file__)
 
+
 @pytest.mark.skip(reason="The tomo module is broken/disabled.")
 class TestPtychoRecon(unittest.TestCase):
     """Test various ptychography reconstruction methods for consistency."""
@@ -72,24 +73,23 @@ class TestPtychoRecon(unittest.TestCase):
         import matplotlib.pyplot as plt
         # Create object
         delta = plt.imread(
-            os.path.join(testdir, "data/Cryptomeria_japonica-0128.tif")
-        )
+            os.path.join(testdir, "data/Cryptomeria_japonica-0128.tif"))
         beta = plt.imread(
-            os.path.join(testdir, "data/Bombus_terrestris-0128.tif")
-        )
+            os.path.join(testdir, "data/Bombus_terrestris-0128.tif"))
         original = np.empty(delta.shape, dtype='complex64')
         original.real = delta / 2550
         original.imag = beta / 2550
         self.original = np.tile(original, (1, 1, 1)).astype('complex64')
         # Define views
-        self.theta = np.linspace(0, np.pi, 201, endpoint=False).astype('float32')
+        self.theta = np.linspace(0, np.pi, 201,
+                                 endpoint=False).astype('float32')
         # Simulate data
         self.data = tike.tomo.simulate(obj=self.original, theta=self.theta)
         setup_data = [
             self.data.astype('complex64'),
             self.theta.astype('float32'),
             self.original.astype('complex64'),
-            ]
+        ]
         with lzma.open(dataset_file, 'wb') as file:
             pickle.dump(setup_data, file)
 
@@ -112,10 +112,10 @@ class TestPtychoRecon(unittest.TestCase):
         theta = xp.array(self.theta)
         original = xp.array(self.original)
         with TomoBackend(
-            ntheta=theta.size,
-            nz=original.shape[0],
-            n=original.shape[1],
-            center=original.shape[1] / 2,
+                ntheta=theta.size,
+                nz=original.shape[0],
+                n=original.shape[1],
+                center=original.shape[1] / 2,
         ) as slv:
             data = slv.fwd(original, theta)
             u1 = slv.adj(data, theta)
@@ -124,7 +124,7 @@ class TestPtychoRecon(unittest.TestCase):
             print()
             print(f"<> = {t1.real.item():06f}{t1.imag.item():+06f}j\n"
                   f"<> = {t2.real.item():06f}{t2.imag.item():+06f}j")
-            xp.testing.assert_allclose(t1, t2,rtol=1e-3)
+            xp.testing.assert_allclose(t1, t2, rtol=1e-3)
 
     def test_consistent_simulate(self):
         """Check tomo.forward for consistency."""
@@ -137,11 +137,11 @@ class TestPtychoRecon(unittest.TestCase):
         When we project at angles 0 and PI/2, the foward operator should be the
         same as taking the sum over the object array along each axis.
         """
-        theta = np.array([0, np.pi/2, np.pi, -np.pi/2], dtype='float32')
+        theta = np.array([0, np.pi / 2, np.pi, -np.pi / 2], dtype='float32')
         size = 11
         original = np.zeros((1, size, size), dtype='complex64')
-        original[0, size//2, :] += 1
-        original[0, :, size//2] += 1j
+        original[0, size // 2, :] += 1
+        original[0, :, size // 2] += 1j
         data = tike.tomo.simulate(original, theta)
         data1 = np.sum(original, axis=1)
         data2 = np.sum(original, axis=2)
@@ -171,6 +171,7 @@ class TestPtychoRecon(unittest.TestCase):
     #             pickle.dump(recon.astype(np.complex64), file)
     #         raise e
     #     np.testing.assert_allclose(recon, standard, rtol=1e-3)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Because:
- It's easier to remember to do when writing tests than having
  to go into another CI file to disable tests