### PR TITLE
REF: Change initial step sizes for line search

### DIFF
--- a/src/tike/operators/cupy/ptycho.py
+++ b/src/tike/operators/cupy/ptycho.py
@@ -165,7 +165,7 @@ class Ptycho(Operator):
                 probe=mode,
                 scan=scan,
                 overwrite=True,
-            )
+            ) / probe.shape[-3]
         return grad_obj
 
     def grad_probe(self, data, psi, scan, probe, n=-1, mode=None):

--- a/src/tike/opt.py
+++ b/src/tike/opt.py
@@ -99,6 +99,7 @@ def conjugate_gradient(
     dir_multi=dir_single,
     update_multi=update_single,
     num_iter=1,
+    step_length=1,
 ):
     """Use conjugate gradient to estimate `x`.
 
@@ -136,6 +137,7 @@ def conjugate_gradient(
             x=x,
             d=dir_list,
             update_multi=update_multi,
+            step_length=step_length,
         )
 
         x = update_multi(x, gamma, dir_list)

--- a/src/tike/opt.py
+++ b/src/tike/opt.py
@@ -140,6 +140,7 @@ def conjugate_gradient(
 
         x = update_multi(x, gamma, dir_list)
 
-        logger.debug("%4d, %.3e, %.7e", (i + 1), gamma, cost)
+        logger.debug("step %d; length %.3e -> %.3e; cost %.6e", i, step_length,
+                     gamma, cost)
 
     return x, cost

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -87,6 +87,7 @@ def update_probe(op, pool, data, psi, scan, probe, num_iter=1):
             cost_function=cost_function,
             grad=grad,
             num_iter=num_iter,
+            step_length=4,
         )
 
     logger.info('%10s cost is %+12.5e', 'probe', cost)
@@ -134,6 +135,7 @@ def update_object(op, pool, data, psi, scan, probe, num_iter=1):
         dir_multi=dir_multi,
         update_multi=update_multi,
         num_iter=num_iter,
+        step_length=8e-5,
     )
 
     logger.info('%10s cost is %+12.5e', 'object', cost)

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -169,12 +169,12 @@ class TestPtychoRecon(unittest.TestCase):
         """Check ptycho.solver.algorithm for consistency."""
         result = {
             'psi': np.ones_like(self.original),
-            'probe': self.probe,
+            'probe': np.ones_like(self.probe),
             'scan': self.scan,
         }
-        # error0 = self.error_metric(self.error_metric(result['psi']))
-        # print('\n', error0)
-        for _ in range(5):
+        error0 = np.inf
+        print()
+        for _ in range(16):
             result['scan'] = self.scan
             result = tike.ptycho.reconstruct(
                 **result,
@@ -186,23 +186,23 @@ class TestPtychoRecon(unittest.TestCase):
                 recover_probe=True,
                 recover_psi=True,
             )
-            # error1 = self.error_metric(result['psi'])
-            # print(error1)
-            # assert error1 < error0
-            # error0 = error1
+            error1 = result['cost']
+            print(error1)
+            assert error1 < error0
+            error0 = error1
 
-        recon_file = os.path.join(testdir,
-                                  f'data/ptycho_{algorithm}.pickle.lzma')
-        if os.path.isfile(recon_file):
-            with lzma.open(recon_file, 'rb') as file:
-                standard = pickle.load(file)
-        else:
-            with lzma.open(recon_file, 'wb') as file:
-                pickle.dump(result['psi'], file)
-            raise FileNotFoundError(
-                f"ptycho '{algorithm}' standard not initialized.")
-        np.testing.assert_array_equal(result['psi'].shape, self.original.shape)
-        np.testing.assert_allclose(result['psi'], standard, atol=1e-3)
+        # recon_file = os.path.join(testdir,
+        #                           f'data/ptycho_{algorithm}.pickle.lzma')
+        # if os.path.isfile(recon_file):
+        #     with lzma.open(recon_file, 'rb') as file:
+        #         standard = pickle.load(file)
+        # else:1
+        #     with lzma.open(recon_file, 'wb') as file:
+        #         pickle.dump(result['psi'], file)
+        #     raise FileNotFoundError(
+        #         f"ptycho '{algorithm}' standard not initialized.")
+        # np.testing.assert_array_equal(result['psi'].shape, self.original.shape)
+        # np.testing.assert_allclose(result['psi'], standard, atol=1e-3)
 
     def test_consistent_combined(self):
         """Check ptycho.solver.combined for consistency."""

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -191,19 +191,6 @@ class TestPtychoRecon(unittest.TestCase):
             assert error1 < error0
             error0 = error1
 
-        # recon_file = os.path.join(testdir,
-        #                           f'data/ptycho_{algorithm}.pickle.lzma')
-        # if os.path.isfile(recon_file):
-        #     with lzma.open(recon_file, 'rb') as file:
-        #         standard = pickle.load(file)
-        # else:1
-        #     with lzma.open(recon_file, 'wb') as file:
-        #         pickle.dump(result['psi'], file)
-        #     raise FileNotFoundError(
-        #         f"ptycho '{algorithm}' standard not initialized.")
-        # np.testing.assert_array_equal(result['psi'].shape, self.original.shape)
-        # np.testing.assert_allclose(result['psi'], standard, atol=1e-3)
-
     def test_consistent_combined(self):
         """Check ptycho.solver.combined for consistency."""
         self.template_consistent_algorithm('combined')


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Decrease the time spend line searching with minimal effort. Related to #61, #60 .

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Adjusted the initial step sizes for the ptychography solver according to my observations from two real datasets. While the probe step size seems to remain on the order of 1, the object step size consistently shrinks to the order of 1e-5. I guessed that this was related the scan area.

My observation is that applying the smaller initial step for the object update decreases times per epoch by an order of magnitude.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [x] Write tests for new functions or explain why they are not needed.
- [ ] Build the documentation successfully
- [x] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
