### PR TITLE
NEW: Add multi-GPU feature to tike ptychography

### DIFF
--- a/src/tike/operators/cupy/convolution.py
+++ b/src/tike/operators/cupy/convolution.py
@@ -18,6 +18,7 @@ class Convolution(Operator, numpy.Convolution):
         pass
 
     def _patch(self, patches, psi, scan, fwd=True):
+        _patch_kernel = cp.RawKernel(_cu_source, "patch")
         max_thread = min(self.probe_shape,
                          _patch_kernel.attributes['max_threads_per_block'])
         grids = (

--- a/src/tike/operators/cupy/operator.py
+++ b/src/tike/operators/cupy/operator.py
@@ -25,7 +25,21 @@ class Operator(ABC):
         return mlist
 
     @classmethod
-    def asarray_multi_split(cls, gpu_count, scan_cpu, data_cpu,  *args, **kwargs):
+    def asarray_multi_split(cls, gpu_count,
+                            scan_cpu, data_cpu,
+                            *args, **kwargs):
+        """Split scan&data and distribute to multiple GPUs.
+
+        Instead of spliting the arrays based on the scanning
+        order, we split them in accordance with the scan
+        positions corresponding to the object sub-images.
+        For example, if we divide a square object image
+        into four sub-images, then the scan positions on
+        the top-left sub-image and their corresponding
+        diffraction patterns will be grouped into the first
+        chunk of scan and data.
+
+        """
         scanmlist = [None] * gpu_count
         datamlist = [None] * gpu_count
         nscan = scan_cpu.shape[1]
@@ -34,14 +48,26 @@ class Operator(ABC):
         xmax = numpy.amax(scan_cpu[:, :, 0])
         ymax = numpy.amax(scan_cpu[:, :, 1])
         for e in range(nscan):
-            xgpuid = scan_cpu[0, e, 0] // (xmax/(gpu_count//2)) - int(scan_cpu[0, e, 0] != 0 and scan_cpu[0, e, 0] % (xmax/(gpu_count//2)) == 0)
-            ygpuid = scan_cpu[0, e, 1] // (ymax/2) - int(scan_cpu[0, e, 1] != 0 and scan_cpu[0, e, 1] % (ymax/2) == 0)
+            xgpuid = scan_cpu[0, e, 0] // (
+                xmax/(gpu_count//2)) - int(scan_cpu[0, e, 0] != 0 and
+                scan_cpu[0, e, 0] % (xmax/(gpu_count//2)) == 0)
+            ygpuid = scan_cpu[0, e, 1] // (
+                ymax/2) - int(scan_cpu[0, e, 1] != 0 and
+                scan_cpu[0, e, 1] % (ymax/2) == 0)
             idx = int(xgpuid*2+ygpuid)
             tmplist[e] = idx
             counter[idx] += 1
         for i in range(gpu_count):
-            tmpscan = numpy.zeros([scan_cpu.shape[0], counter[i], scan_cpu.shape[2]], dtype=scan_cpu.dtype)
-            tmpdata = numpy.zeros([data_cpu.shape[0], counter[i], data_cpu.shape[2], data_cpu.shape[3]], dtype=data_cpu.dtype)
+            tmpscan = numpy.zeros(
+                [scan_cpu.shape[0], counter[i], scan_cpu.shape[2]],
+                dtype=scan_cpu.dtype,
+            )
+            tmpdata = numpy.zeros(
+                [data_cpu.shape[0], counter[i],
+                 data_cpu.shape[2], data_cpu.shape[3],
+                ],
+                dtype=data_cpu.dtype,
+            )
             c = 0
             for e in range(nscan):
                 if tmplist[e] == i:
@@ -57,11 +83,22 @@ class Operator(ABC):
 
     @classmethod
     def asarray_multi_fuse(cls, gpu_count, *args, **kwargs):
+        """Collect and fuse the data into one GPU.
+
+        Each element of the args, e.g., args[0] is
+        expected to be a list of cupy array.
+        The size of each list is the same as
+        gpu_count.
+
+        """
         with cupy.cuda.Device(0):
             fused = args[0][0].copy()
         for i in range(1, gpu_count):
             with cupy.cuda.Device(i):
                 fused_cpu = cupy.asnumpy(args[0][i])
                 with cupy.cuda.Device(0):
-                    fused = cupy.concatenate((fused, cupy.asarray(fused_cpu)), axis=1)
+                    fused = cupy.concatenate(
+                        (fused, cupy.asarray(fused_cpu)),
+                        axis=1,
+                    )
         return fused

--- a/src/tike/operators/cupy/operator.py
+++ b/src/tike/operators/cupy/operator.py
@@ -58,16 +58,10 @@ class Operator(ABC):
     @classmethod
     def asarray_multi_fuse(cls, gpu_count, *args, **kwargs):
         with cupy.cuda.Device(0):
-            #scanf = scan[0].copy()
-            #dataf = data[0].copy()
             fused = args[0][0].copy()
         for i in range(1, gpu_count):
             with cupy.cuda.Device(i):
-                #scan_cpu = cupy.asnumpy(scan[i])
-                #data_cpu = cupy.asnumpy(data[i])
                 fused_cpu = cupy.asnumpy(args[0][i])
                 with cupy.cuda.Device(0):
-                    #scanf=cupy.concatenate((scanf, cupy.asarray(scan_cpu)), axis=1)
-                    #dataf=cupy.concatenate((dataf, cupy.asarray(data_cpu)), axis=1)
                     fused = cupy.concatenate((fused, cupy.asarray(fused_cpu)), axis=1)
         return fused

--- a/src/tike/operators/cupy/operator.py
+++ b/src/tike/operators/cupy/operator.py
@@ -1,5 +1,6 @@
 from abc import ABC
 
+import numpy
 import cupy
 
 
@@ -14,3 +15,42 @@ class Operator(ABC):
     @classmethod
     def asnumpy(cls, *args, **kwargs):
         return cupy.asnumpy(*args, **kwargs)
+
+    @classmethod
+    def asarray_multi(cls, gpu_count, *args, **kwargs):
+        mlist = [None] * gpu_count
+        for i in range(gpu_count):
+            with cupy.cuda.Device(i):
+                mlist[i] = cupy.asarray(*args, **kwargs)
+        return mlist
+
+    @classmethod
+    def asarray_multi_split(cls, gpu_count, scan_cpu, data_cpu,  *args, **kwargs):
+        scanmlist = [None] * gpu_count
+        datamlist = [None] * gpu_count
+        nscan = scan_cpu.shape[1]
+        tmplist = [0] * nscan
+        counter = [0] * gpu_count
+        xmax = numpy.amax(scan_cpu[:, :, 0])
+        ymax = numpy.amax(scan_cpu[:, :, 1])
+        for e in range(nscan):
+            xgpuid = scan_cpu[0, e, 0] // (xmax/(gpu_count//2)) - int(scan_cpu[0, e, 0] != 0 and scan_cpu[0, e, 0] % (xmax/(gpu_count//2)) == 0)
+            ygpuid = scan_cpu[0, e, 1] // (ymax/2) - int(scan_cpu[0, e, 1] != 0 and scan_cpu[0, e, 1] % (ymax/2) == 0)
+            idx = int(xgpuid*2+ygpuid)
+            tmplist[e] = idx
+            counter[idx] += 1
+        for i in range(gpu_count):
+            tmpscan = numpy.zeros([scan_cpu.shape[0], counter[i], scan_cpu.shape[2]], dtype=scan_cpu.dtype)
+            tmpdata = numpy.zeros([data_cpu.shape[0], counter[i], data_cpu.shape[2], data_cpu.shape[3]], dtype=data_cpu.dtype)
+            c = 0
+            for e in range(nscan):
+                if tmplist[e] == i:
+                    tmpscan[:, c, :] = scan_cpu[:, e, :]
+                    tmpdata[:, c] = data_cpu[:, e]
+                    c += 1
+            with cupy.cuda.Device(i):
+                scanmlist[i] = cupy.asarray(tmpscan)
+                datamlist[i] = cupy.asarray(tmpdata)
+            del tmpscan
+            del tmpdata
+        return scanmlist, datamlist

--- a/src/tike/operators/cupy/operator.py
+++ b/src/tike/operators/cupy/operator.py
@@ -54,3 +54,15 @@ class Operator(ABC):
             del tmpscan
             del tmpdata
         return scanmlist, datamlist
+
+    @classmethod
+    def asarray_multi_fuse(cls, gpu_count, scan, data, *args, **kwargs):
+        for i in range(1, gpu_count):
+            with cupy.cuda.Device(i):
+                scan_cpu = cupy.asnumpy(scan[i])
+                data_cpu = cupy.asnumpy(data[i])
+                with cupy.cuda.Device(0):
+                    scan[0]=cupy.concatenate((scan[0], cupy.asarray(scan_cpu)), axis=1)
+                    data[0]=cupy.concatenate((data[0], cupy.asarray(data_cpu)), axis=1)
+        print('test', scan[0].shape, data[0].shape)
+        return scan[0], data[0]

--- a/src/tike/operators/cupy/operator.py
+++ b/src/tike/operators/cupy/operator.py
@@ -48,12 +48,12 @@ class Operator(ABC):
         xmax = numpy.amax(scan_cpu[:, :, 0])
         ymax = numpy.amax(scan_cpu[:, :, 1])
         for e in range(nscan):
-            xgpuid = scan_cpu[0, e, 0] // (
-                xmax/(gpu_count//2)) - int(scan_cpu[0, e, 0] != 0 and
-                scan_cpu[0, e, 0] % (xmax/(gpu_count//2)) == 0)
-            ygpuid = scan_cpu[0, e, 1] // (
-                ymax/2) - int(scan_cpu[0, e, 1] != 0 and
-                scan_cpu[0, e, 1] % (ymax/2) == 0)
+            xgpuid = scan_cpu[0, e, 0] // (xmax/(gpu_count//2)) - int(
+                        scan_cpu[0, e, 0] != 0 and
+                        scan_cpu[0, e, 0] % (xmax/(gpu_count//2)) == 0)
+            ygpuid = scan_cpu[0, e, 1] // (ymax/2) - int(
+                        scan_cpu[0, e, 1] != 0 and
+                        scan_cpu[0, e, 1] % (ymax/2) == 0)
             idx = int(xgpuid*2+ygpuid)
             tmplist[e] = idx
             counter[idx] += 1
@@ -64,8 +64,7 @@ class Operator(ABC):
             )
             tmpdata = numpy.zeros(
                 [data_cpu.shape[0], counter[i],
-                 data_cpu.shape[2], data_cpu.shape[3],
-                ],
+                 data_cpu.shape[2], data_cpu.shape[3]],
                 dtype=data_cpu.dtype,
             )
             c = 0

--- a/src/tike/operators/cupy/operator.py
+++ b/src/tike/operators/cupy/operator.py
@@ -56,16 +56,18 @@ class Operator(ABC):
         return scanmlist, datamlist
 
     @classmethod
-    def asarray_multi_fuse(cls, gpu_count, scan, data, *args, **kwargs):
+    def asarray_multi_fuse(cls, gpu_count, *args, **kwargs):
         with cupy.cuda.Device(0):
-            scanf = scan[0].copy()
-            dataf = data[0].copy()
+            #scanf = scan[0].copy()
+            #dataf = data[0].copy()
+            fused = args[0][0].copy()
         for i in range(1, gpu_count):
             with cupy.cuda.Device(i):
-                scan_cpu = cupy.asnumpy(scan[i])
-                data_cpu = cupy.asnumpy(data[i])
+                #scan_cpu = cupy.asnumpy(scan[i])
+                #data_cpu = cupy.asnumpy(data[i])
+                fused_cpu = cupy.asnumpy(args[0][i])
                 with cupy.cuda.Device(0):
-                    scanf=cupy.concatenate((scanf, cupy.asarray(scan_cpu)), axis=1)
-                    dataf=cupy.concatenate((dataf, cupy.asarray(data_cpu)), axis=1)
-        print('test', scanf.shape, dataf.shape)
-        return scanf, dataf
+                    #scanf=cupy.concatenate((scanf, cupy.asarray(scan_cpu)), axis=1)
+                    #dataf=cupy.concatenate((dataf, cupy.asarray(data_cpu)), axis=1)
+                    fused = cupy.concatenate((fused, cupy.asarray(fused_cpu)), axis=1)
+        return fused

--- a/src/tike/operators/cupy/operator.py
+++ b/src/tike/operators/cupy/operator.py
@@ -57,12 +57,15 @@ class Operator(ABC):
 
     @classmethod
     def asarray_multi_fuse(cls, gpu_count, scan, data, *args, **kwargs):
+        with cupy.cuda.Device(0):
+            scanf = scan[0].copy()
+            dataf = data[0].copy()
         for i in range(1, gpu_count):
             with cupy.cuda.Device(i):
                 scan_cpu = cupy.asnumpy(scan[i])
                 data_cpu = cupy.asnumpy(data[i])
                 with cupy.cuda.Device(0):
-                    scan[0]=cupy.concatenate((scan[0], cupy.asarray(scan_cpu)), axis=1)
-                    data[0]=cupy.concatenate((data[0], cupy.asarray(data_cpu)), axis=1)
-        print('test', scan[0].shape, data[0].shape)
-        return scan[0], data[0]
+                    scanf=cupy.concatenate((scanf, cupy.asarray(scan_cpu)), axis=1)
+                    dataf=cupy.concatenate((dataf, cupy.asarray(data_cpu)), axis=1)
+        print('test', scanf.shape, dataf.shape)
+        return scanf, dataf

--- a/src/tike/operators/cupy/ptycho.py
+++ b/src/tike/operators/cupy/ptycho.py
@@ -84,6 +84,12 @@ class Ptycho(Operator, numpy.Ptycho):
 
         return grad_list[0]
 
+    # scatter dir to all GPUs
+    def dir_multi(self, gpu_count, dir):  # lists of cupy array
+        dir_cpu = Operator.asnumpy(dir)
+        dir_list = Operator.asarray_multi(gpu_count, dir_cpu)
+        return dir_list
+
     # multi-GPU update()
     def update_multi(self, gpu_count, psi, gamma, dir):  # lists of cupy array
         for i in range(gpu_count):

--- a/src/tike/operators/cupy/ptycho.py
+++ b/src/tike/operators/cupy/ptycho.py
@@ -36,7 +36,8 @@ class Ptycho(Operator, numpy.Ptycho):
 
         gpu_list = range(gpu_count)
         with cf.ThreadPoolExecutor(max_workers=gpu_count) as executor:
-            cost_out = executor.map(self.cost_device, gpu_list,
+            cost_out = executor.map(
+                self.cost_device, gpu_list,
                 data, psi_list, scan, probe,
             )
         cost_list = list(cost_out)
@@ -58,7 +59,8 @@ class Ptycho(Operator, numpy.Ptycho):
                    data, psi, scan, probe):  # lists of cupy array
         gpu_list = range(gpu_count)
         with cf.ThreadPoolExecutor(max_workers=gpu_count) as executor:
-            grad_out = executor.map(self.grad_device, gpu_list,
+            grad_out = executor.map(
+                self.grad_device, gpu_list,
                 data, psi, scan, probe,
             )
         grad_list = list(grad_out)
@@ -68,7 +70,8 @@ class Ptycho(Operator, numpy.Ptycho):
             for i in range(1, gpu_count):
                 if cp.cuda.runtime.deviceCanAccessPeer(0, i):
                     cp.cuda.runtime.deviceEnablePeerAccess(i)
-                    grad_tmp.data.copy_from_device(grad_list[i].data,
+                    grad_tmp.data.copy_from_device(
+                        grad_list[i].data,
                         grad_list[0].size*grad_list[0].itemsize,
                     )
                 else:

--- a/src/tike/operators/cupy/ptycho.py
+++ b/src/tike/operators/cupy/ptycho.py
@@ -29,8 +29,6 @@ class Ptycho(Operator, numpy.Ptycho):
         for i in range(gpu_count):
             if 'step_length' in kwargs and 'dir' in kwargs:
                 with cp.cuda.Device(i):
-                    #print('testpsii:', i, psi[i].tolist())
-                    #print('testdiri:', i,(kwargs.get('step_length')*kwargs.get('dir')[i]).tolist())
                     psi_list[i] = psi[i] + kwargs.get('step_length') * kwargs.get('dir')[i]
             else:
                 psi_list[i] = psi[i]
@@ -67,7 +65,6 @@ class Ptycho(Operator, numpy.Ptycho):
 
     # multi-GPU grad() entry point
     def grad_multi(self, gpu_count, data, psi, scan, probe):  # lists of cupy array
-        #intensity = self._compute_intensity_multi(gpu_id, data, psi, scan, probe) # intensity is a list of cupy arrays
         gpu_list = range(gpu_count)
         with cf.ThreadPoolExecutor(max_workers=gpu_count) as executor:
             grad_out = executor.map(self.grad_device, gpu_list, data, psi, scan, probe)
@@ -86,9 +83,6 @@ class Ptycho(Operator, numpy.Ptycho):
                 grad_list[0] += grad_tmp
 
         return grad_list[0]
-        #print('testgrad2:', grad_tmp.shape)
-        #print('testgrad:', grad_list[0].tolist())
-        #print('testgrad1:', grad_list[1].tolist())
 
     # multi-GPU update()
     def update_multi(self, gpu_count, psi, gamma, dir):  # lists of cupy array

--- a/src/tike/operators/cupy/ptycho.py
+++ b/src/tike/operators/cupy/ptycho.py
@@ -2,6 +2,11 @@ from tike.operators import numpy
 from .convolution import Convolution
 from .propagation import Propagation
 from .operator import Operator
+import concurrent.futures as cf
+import threading
+from functools import partial
+import cupy as cp
+import numpy as np
 
 
 class Ptycho(Operator, numpy.Ptycho):
@@ -12,3 +17,82 @@ class Ptycho(Operator, numpy.Ptycho):
             diffraction=Convolution,
             **kwargs,
         )
+
+    def cost_device(self, gpu_id, data, psi, scan, probe, n=-1, mode=None): # cupy arrays
+        with cp.cuda.Device(gpu_id):
+            intensity = self._compute_intensity(data, psi, scan, probe, n, mode)
+            return self.propagation.cost(data, intensity)
+
+    # multi-GPU cost() entry point
+    def cost_multi(self, gpu_count, data, psi, scan, probe, n=-1, mode=None, **kwargs):  # lists of cupy array
+        psi_list = [None] * gpu_count
+        for i in range(gpu_count):
+            if 'step_length' in kwargs and 'dir' in kwargs:
+                with cp.cuda.Device(i):
+                    #print('testpsii:', i, psi[i].tolist())
+                    #print('testdiri:', i,(kwargs.get('step_length')*kwargs.get('dir')[i]).tolist())
+                    psi_list[i] = psi[i] + kwargs.get('step_length') * kwargs.get('dir')[i]
+            else:
+                psi_list[i] = psi[i]
+
+        gpu_list = range(gpu_count)
+        with cf.ThreadPoolExecutor(max_workers=gpu_count) as executor:
+            cost_out = executor.map(self.cost_device, gpu_list, data, psi_list, scan, probe)
+        cost_list = list(cost_out)
+
+        cost_cpu = np.zeros(cost_list[0].shape, cost_list[0].dtype)
+        for i in range(gpu_count):
+            with cp.cuda.Device(i):
+                cost_cpu += Operator.asnumpy(cost_list[i])
+
+        return cost_cpu
+
+    def grad_device(self, gpu_id, data, psi, scan, probe):  # cupy arrays
+        with cp.cuda.Device(gpu_id):
+            intensity = self._compute_intensity(data, psi, scan, probe)
+            grad_obj = self.xp.zeros_like(psi)
+            for mode in cp.split(probe, probe.shape[-3], axis=-3):
+                # TODO: Pass obj through adj() instead of making new obj inside
+                grad_obj += self.adj(
+                    farplane=self.propagation.grad(
+                        data,
+                        self.fwd(psi=psi, scan=scan, probe=mode),
+                        intensity,
+                    ),
+                    probe=mode,
+                    scan=scan,
+                    overwrite=True,
+                )
+            return grad_obj
+
+    # multi-GPU grad() entry point
+    def grad_multi(self, gpu_count, data, psi, scan, probe):  # lists of cupy array
+        #intensity = self._compute_intensity_multi(gpu_id, data, psi, scan, probe) # intensity is a list of cupy arrays
+        gpu_list = range(gpu_count)
+        with cf.ThreadPoolExecutor(max_workers=gpu_count) as executor:
+            grad_out = executor.map(self.grad_device, gpu_list, data, psi, scan, probe)
+        grad_list = list(grad_out)
+
+        with cp.cuda.Device(0):
+            grad_tmp = cp.empty(grad_list[0].shape, grad_list[0].dtype)
+            for i in range(1, gpu_count):
+                if cp.cuda.runtime.deviceCanAccessPeer(0, i):
+                    cp.cuda.runtime.deviceEnablePeerAccess(i)
+                    grad_tmp.data.copy_from_device(grad_list[i].data, grad_list[0].size*grad_list[0].itemsize)
+                else:
+                    with cp.cuda.Device(i):
+                        grad_cpu_tmp = Operator.asnumpy(grad_list[i])
+                    grad_tmp = Operator.asarray(grad_cpu_tmp)
+                grad_list[0] += grad_tmp
+
+        return grad_list[0]
+        #print('testgrad2:', grad_tmp.shape)
+        #print('testgrad:', grad_list[0].tolist())
+        #print('testgrad1:', grad_list[1].tolist())
+
+    # multi-GPU update()
+    def update_multi(self, gpu_count, psi, gamma, dir):  # lists of cupy array
+        for i in range(gpu_count):
+            with cp.cuda.Device(i):
+                psi[i] = psi[i] + gamma * dir[i]
+        return psi

--- a/src/tike/operators/numpy/operator.py
+++ b/src/tike/operators/numpy/operator.py
@@ -2,6 +2,7 @@ from abc import ABC
 
 import numpy
 
+
 class Operator(ABC):
     """A base class for Operators.
 

--- a/src/tike/opt.py
+++ b/src/tike/opt.py
@@ -120,7 +120,6 @@ def conjugate_gradient(
                 num_gpu=num_gpu,
             )
             x = x + gamma * dir
-            #print('test', x.shape, x.tolist())
         else:
             # scatter dir to all GPUs
             dir_cpu = Operator.asnumpy(dir)
@@ -134,6 +133,5 @@ def conjugate_gradient(
             )
             # update the image
             x = update(x, gamma, dir_list)
-            #print('test', type(x), x[1].shape, x[1].tolist())
         logger.debug("%4d, %.3e, %.7e", (i + 1), gamma, cost)
     return x, cost

--- a/src/tike/opt.py
+++ b/src/tike/opt.py
@@ -9,7 +9,6 @@ library.
 
 import logging
 import warnings
-from tike.operators.cupy.operator import Operator
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +84,7 @@ def conjugate_gradient(
         x,
         cost_function,
         grad,
+        dir_multi=None,
         update=None,
         num_gpu=1,
         num_iter=1,
@@ -121,9 +121,7 @@ def conjugate_gradient(
             )
             x = x + gamma * dir
         else:
-            # scatter dir to all GPUs
-            dir_cpu = Operator.asnumpy(dir)
-            dir_list = Operator.asarray_multi(num_gpu, dir_cpu)
+            dir_list = dir_multi(dir)
 
             gamma, cost = line_search(
                 f=cost_function,

--- a/src/tike/opt.py
+++ b/src/tike/opt.py
@@ -120,7 +120,7 @@ def conjugate_gradient(
                 num_gpu=num_gpu,
             )
             x = x + gamma * dir
-            print('test', x.shape, x.tolist())
+            #print('test', x.shape, x.tolist())
         else:
             # scatter dir to all GPUs
             dir_cpu = Operator.asnumpy(dir)
@@ -134,7 +134,6 @@ def conjugate_gradient(
             )
             # update the image
             x = update(x, gamma, dir_list)
-            print('test', type(x), x[1].shape, x[1].tolist())
+            #print('test', type(x), x[1].shape, x[1].tolist())
         logger.debug("%4d, %.3e, %.7e", (i + 1), gamma, cost)
-    exit()
     return x, cost

--- a/src/tike/opt.py
+++ b/src/tike/opt.py
@@ -81,6 +81,8 @@ def conjugate_gradient(
         x,
         cost_function,
         grad,
+        update=None,
+        mGPU=False,
         num_iter=1,
 ):
     """Use conjugate gradient to estimate `x`.
@@ -99,6 +101,8 @@ def conjugate_gradient(
         The number of steps to take.
 
     """
+    print('test', mGPU)
+    exit()
     for i in range(num_iter):
         grad1 = grad(x)
         if i == 0:

--- a/src/tike/opt.py
+++ b/src/tike/opt.py
@@ -46,10 +46,10 @@ def line_search(f, x, d, num_gpu, step_length=1, step_shrink=0.5):
     fx = f(x)  # Save the result of f(x) instead of computing it many times
     # Decrease the step length while the step increases the cost function
     while True:
-        if (num_gpu<=1):
+        if (num_gpu <= 1):
             fxsd = f(x + step_length * d)
         else:
-            fxsd = f(x, step_length = step_length, dir = d)
+            fxsd = f(x, step_length=step_length, dir=d)
         if fxsd <= fx + step_shrink * m:
             break
         step_length *= step_shrink
@@ -85,7 +85,7 @@ def conjugate_gradient(
         cost_function,
         grad,
         dir_multi=None,
-        update=None,
+        update_multi=None,
         num_gpu=1,
         num_iter=1,
 ):
@@ -101,6 +101,10 @@ def conjugate_gradient(
         The function being minimized to recover x.
     grad : func(x) -> array_like
         The gradient of cost_function.
+    dir_multi : func(x) -> list_of_array
+        The dir in all GPUs.
+    update_multi : func(x) -> list_of_array
+        The updated subimages in all GPUs.
     num_iter : int
         The number of steps to take.
 
@@ -112,7 +116,7 @@ def conjugate_gradient(
         else:
             dir = direction_dy(array_module, grad0, grad1, dir)
         grad0 = grad1
-        if (num_gpu<=1):
+        if (num_gpu <= 1):
             gamma, cost = line_search(
                 f=cost_function,
                 x=x,
@@ -130,6 +134,6 @@ def conjugate_gradient(
                 num_gpu=num_gpu,
             )
             # update the image
-            x = update(x, gamma, dir_list)
+            x = update_multi(x, gamma, dir_list)
         logger.debug("%4d, %.3e, %.7e", (i + 1), gamma, cost)
     return x, cost

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -212,6 +212,16 @@ def reconstruct(
                     break
                 cost = result['cost']
 
+            if (num_gpu>1):
+                result['scan'] = operator.asarray_multi_fuse(num_gpu, result['scan'])
+                print('scan', type(result['scan']), result['scan'].shape)
+                for k, v in result.items():
+                    if isinstance(v, list):
+                        print('list', k)
+                        result[k] = v[0]
+            for k, v in result.items():
+                print('result',k, type(v), v.shape)
+            exit()
         return {k: operator.asnumpy(v) for k, v in result.items()}
     else:
         raise ValueError(

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -189,7 +189,6 @@ def reconstruct(
                 for key, value in kwargs.items():
                     if np.ndim(value) > 0:
                         kwargs[key] = operator.asarray_multi(num_gpu, value)
-                print('data', type(data), data[0].dtype, data[1].shape)
 
             cost = 0
             for i in range(num_iter):
@@ -197,12 +196,6 @@ def reconstruct(
                                                      result['psi'],
                                                      result['scan'],
                                                      result['probe'])
-                if (num_gpu>1):
-                    print('probe',probe[0].shape, probe[0].tolist())
-                    print(type(data),data[0].shape, type(scan), scan[0].shape)
-                else:
-                    print('probe',probe.shape, probe.tolist())
-                    print(type(data),data.shape, type(scan), scan.shape)
                 kwargs.update(result)
                 result = getattr(solvers, algorithm)(
                     operator,
@@ -220,13 +213,9 @@ def reconstruct(
 
             if (num_gpu>1):
                 result['scan'] = operator.asarray_multi_fuse(num_gpu, result['scan'])
-                print('scan', type(result['scan']), result['scan'].shape)
                 for k, v in result.items():
                     if isinstance(v, list):
-                        print('list', k)
                         result[k] = v[0]
-            for k, v in result.items():
-                print('result',k, type(v), v.shape)
         return {k: operator.asnumpy(v) for k, v in result.items()}
     else:
         raise ValueError(
@@ -244,7 +233,6 @@ def _rescale_obj_probe(operator, num_gpu, data, psi, scan, probe):
 
     intensity = operator._compute_intensity(data, psi, scan, probe)
 
-    print('test', type(data))
     rescale = (np.linalg.norm(np.ravel(np.sqrt(data))) /
                np.linalg.norm(np.ravel(np.sqrt(intensity))))
 

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -179,10 +179,20 @@ def reconstruct(
                 logger.info("{} for {:,d} - {:,d} by {:,d} frames for {:,d} "
                             "iterations.".format(algorithm, *data.shape[1:],
                                                  num_iter))
-
-                cost = 0
             else:
-                pass
+                scan, data = operator.asarray_multi_split(num_gpu, scan, data)
+                result = {
+                    'psi': operator.asarray_multi(num_gpu, psi, dtype='complex64'),
+                    'probe': operator.asarray_multi(num_gpu, probe, dtype='complex64'),
+                    'scan': scan,
+                }
+                for key, value in kwargs.items():
+                    if np.ndim(value) > 0:
+                        kwargs[key] = operator.asarray_multi(num_gpu, value)
+                print('data', type(data), data[0].dtype, data[1].shape)
+            exit()
+
+            cost = 0
             for i in range(num_iter):
                 result['probe'] = _rescale_obj_probe(operator, num_gpu, data,
                                                      result['psi'],
@@ -213,6 +223,7 @@ def _rescale_obj_probe(operator, num_gpu, data, psi, scan, probe):
     if (num_gpu<=1):
         intensity = operator._compute_intensity(data, psi, scan, probe)
 
+        print('test', type(data))
         rescale = (np.linalg.norm(np.ravel(np.sqrt(data))) /
                    np.linalg.norm(np.ravel(np.sqrt(intensity))))
 

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -163,8 +163,11 @@ def reconstruct(
                 ntheta=scan.shape[0],
                 **kwargs,
         ) as operator:
-            if (num_gpu <= 1):
+            logger.info("{} for {:,d} - {:,d} by {:,d} frames for {:,d} "
+                        "iterations.".format(algorithm, *data.shape[1:],
+                                                num_iter))
             # send any array-likes to device
+            if (num_gpu <= 1):
                 data = operator.asarray(data, dtype='float32')
                 result = {
                     'psi': operator.asarray(psi, dtype='complex64'),
@@ -174,10 +177,6 @@ def reconstruct(
                 for key, value in kwargs.items():
                     if np.ndim(value) > 0:
                         kwargs[key] = operator.asarray(value)
-
-                logger.info("{} for {:,d} - {:,d} by {:,d} frames for {:,d} "
-                            "iterations.".format(algorithm, *data.shape[1:],
-                                                 num_iter))
             else:
                 scan, data = operator.asarray_multi_split(
                     num_gpu,

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -57,7 +57,6 @@ __all__ = [
 
 import logging
 import numpy as np
-import cupy as cp
 
 from tike.operators import Ptycho
 from tike.ptycho import solvers

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -190,17 +190,17 @@ def reconstruct(
                     if np.ndim(value) > 0:
                         kwargs[key] = operator.asarray_multi(num_gpu, value)
                 print('data', type(data), data[0].dtype, data[1].shape)
-            exit()
 
             cost = 0
             for i in range(num_iter):
-                result['probe'] = _rescale_obj_probe(operator, num_gpu, data,
-                                                     result['psi'],
-                                                     result['scan'],
-                                                     result['probe'])
+                #result['probe'] = _rescale_obj_probe(operator, num_gpu, data,
+                #                                     result['psi'],
+                #                                     result['scan'],
+                #                                     result['probe'])
                 kwargs.update(result)
                 result = getattr(solvers, algorithm)(
                     operator,
+                    num_gpu=num_gpu,
                     data=data,
                     **kwargs,
                 )

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -64,9 +64,7 @@ def update_probe(op, num_gpu, data, psi, scan, probe, num_iter=1):
         probe = op.asarray_multi(num_gpu, probe)
         del scan
         del data
-        print('probe',cost,probe[0].shape, probe[0].tolist())
-    else:
-        print('probe',cost,probe.shape, probe.tolist())
+
     logger.info('%10s cost is %+12.5e', 'probe', cost)
     return probe, cost
 

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -17,10 +17,26 @@ def combined(
 
     """
     if recover_psi:
-        psi, cost = update_object(op, num_gpu, data, psi, scan, probe, num_iter=cg_iter)
+        psi, cost = update_object(
+            op,
+            num_gpu,
+            data,
+            psi,
+            scan,
+            probe,
+            num_iter=cg_iter,
+        )
 
     if recover_probe:
-        probe, cost = update_probe(op, num_gpu, data, psi, scan, probe, num_iter=cg_iter)
+        probe, cost = update_probe(
+            op,
+            num_gpu,
+            data,
+            psi,
+            scan,
+            probe,
+            num_iter=cg_iter,
+        )
 
     if recover_positions:
         scan, cost = update_positions_pd(op, data, psi, probe, scan)
@@ -31,7 +47,7 @@ def combined(
 def update_probe(op, num_gpu, data, psi, scan, probe, num_iter=1):
     """Solve the probe recovery problem."""
     # TODO: add multi-GPU support
-    if (num_gpu>1):
+    if (num_gpu > 1):
         scan = op.asarray_multi_fuse(num_gpu, scan)
         data = op.asarray_multi_fuse(num_gpu, data)
         psi = psi[0]
@@ -59,7 +75,7 @@ def update_probe(op, num_gpu, data, psi, scan, probe, num_iter=1):
             num_iter=num_iter,
         )
 
-    if (num_gpu>1):
+    if (num_gpu > 1):
         probe = op.asarray_multi(num_gpu, probe)
         del scan
         del data
@@ -88,7 +104,7 @@ def update_object(op, num_gpu, data, psi, scan, probe, num_iter=1):
     def update_multi(psi, *args):
         return op.update_multi(num_gpu, psi, *args)
 
-    if (num_gpu<=1):
+    if (num_gpu <= 1):
         psi, cost = conjugate_gradient(
             op.xp,
             x=psi,
@@ -104,7 +120,7 @@ def update_object(op, num_gpu, data, psi, scan, probe, num_iter=1):
             cost_function=cost_function_multi,
             grad=grad_multi,
             dir_multi=dir_multi,
-            update=update_multi,
+            update_multi=update_multi,
             num_gpu=num_gpu,
             num_iter=num_iter,
         )

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -33,7 +33,8 @@ def update_probe(op, num_gpu, data, psi, scan, probe, num_iter=1):
     """Solve the probe recovery problem."""
     # TODO: add multi-GPU support
     if (num_gpu>1):
-        scan, data = op.asarray_multi_fuse(num_gpu, scan, data)
+        scan = op.asarray_multi_fuse(num_gpu, scan)
+        data = op.asarray_multi_fuse(num_gpu, data)
         psi = psi[0]
         probe = probe[0]
 

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -80,7 +80,7 @@ def update_object(op, num_gpu, data, psi, scan, probe, num_iter=1):
             x=psi,
             cost_function=cost_function,
             grad=grad,
-            mGPU=False,
+            num_gpu=num_gpu,
             num_iter=num_iter,
         )
     else:
@@ -90,7 +90,7 @@ def update_object(op, num_gpu, data, psi, scan, probe, num_iter=1):
             cost_function=cost_function_multi,
             grad=grad_multi,
             update=update_multi,
-            mGPU=True,
+            num_gpu=num_gpu,
             num_iter=num_iter,
         )
 

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -24,7 +24,6 @@ def combined(
 
     if recover_positions:
         scan, cost = update_positions_pd(op, data, psi, probe, scan)
-    print('psi',type(probe), type(cost),type(scan), scan[0].shape)
 
     return {'psi': psi, 'probe': probe, 'cost': cost, 'scan': scan}
 
@@ -71,7 +70,6 @@ def update_probe(op, num_gpu, data, psi, scan, probe, num_iter=1):
 
 def update_object(op, num_gpu, data, psi, scan, probe, num_iter=1):
     """Solve the object recovery problem."""
-    print('data', data[0].shape)
     def cost_function(psi):
         return op.cost(data, psi, scan, probe)
 
@@ -106,7 +104,6 @@ def update_object(op, num_gpu, data, psi, scan, probe, num_iter=1):
             num_gpu=num_gpu,
             num_iter=num_iter,
         )
-
 
     logger.info('%10s cost is %+12.5e', 'object', cost)
     return psi, cost

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 def combined(
     op,
-    data, probe, scan, psi,
+    num_gpu, data, probe, scan, psi,
     recover_psi=True, recover_probe=True, recover_positions=False,
     cg_iter=4,
     **kwargs
@@ -17,10 +17,10 @@ def combined(
 
     """
     if recover_psi:
-        psi, cost = update_object(op, data, psi, scan, probe, num_iter=cg_iter)
+        psi, cost = update_object(op, num_gpu, data, psi, scan, probe, num_iter=cg_iter)
 
     if recover_probe:
-        probe, cost = update_probe(op, data, psi, scan, probe, num_iter=cg_iter)
+        probe, cost = update_probe(op, num_gpu, data, psi, scan, probe, num_iter=cg_iter)
 
     if recover_positions:
         scan, cost = update_positions_pd(op, data, psi, probe, scan)
@@ -28,7 +28,7 @@ def combined(
     return {'psi': psi, 'probe': probe, 'cost': cost, 'scan': scan}
 
 
-def update_probe(op, data, psi, scan, probe, num_iter=1):
+def update_probe(op, num_gpu, data, psi, scan, probe, num_iter=1):
     """Solve the probe recovery problem."""
     # TODO: Cache object patche between mode updates
     for m in range(probe.shape[-3]):
@@ -56,7 +56,7 @@ def update_probe(op, data, psi, scan, probe, num_iter=1):
     return probe, cost
 
 
-def update_object(op, data, psi, scan, probe, num_iter=1):
+def update_object(op, num_gpu, data, psi, scan, probe, num_iter=1):
     """Solve the object recovery problem."""
 
     def cost_function(psi):
@@ -65,13 +65,35 @@ def update_object(op, data, psi, scan, probe, num_iter=1):
     def grad(psi):
         return op.grad(data, psi, scan, probe)
 
-    psi, cost = conjugate_gradient(
-        op.xp,
-        x=psi,
-        cost_function=cost_function,
-        grad=grad,
-        num_iter=num_iter,
-    )
+    def cost_function_multi(psi, **kwargs):
+        return op.cost_multi(num_gpu, data, psi, scan, probe, **kwargs)
+
+    def grad_multi(psi):
+        return op.grad_multi(num_gpu, data, psi, scan, probe)
+
+    def update_multi(psi, *args):
+        return op.update_multi(num_gpu, psi, *args)
+
+    if (num_gpu<=1):
+        psi, cost = conjugate_gradient(
+            op.xp,
+            x=psi,
+            cost_function=cost_function,
+            grad=grad,
+            mGPU=False,
+            num_iter=num_iter,
+        )
+    else:
+        psi, cost = conjugate_gradient(
+            op.xp,
+            x=psi,
+            cost_function=cost_function_multi,
+            grad=grad_multi,
+            update=update_multi,
+            mGPU=True,
+            num_iter=num_iter,
+        )
+
 
     logger.info('%10s cost is %+12.5e', 'object', cost)
     return psi, cost

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -82,6 +82,9 @@ def update_object(op, num_gpu, data, psi, scan, probe, num_iter=1):
     def grad_multi(psi):
         return op.grad_multi(num_gpu, data, psi, scan, probe)
 
+    def dir_multi(*args):
+        return op.dir_multi(num_gpu, *args)
+
     def update_multi(psi, *args):
         return op.update_multi(num_gpu, psi, *args)
 
@@ -100,6 +103,7 @@ def update_object(op, num_gpu, data, psi, scan, probe, num_iter=1):
             x=psi,
             cost_function=cost_function_multi,
             grad=grad_multi,
+            dir_multi=dir_multi,
             update=update_multi,
             num_gpu=num_gpu,
             num_iter=num_iter,

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -24,6 +24,7 @@ def combined(
 
     if recover_positions:
         scan, cost = update_positions_pd(op, data, psi, probe, scan)
+    print('psi',type(probe), type(cost),type(scan), scan[0].shape)
 
     return {'psi': psi, 'probe': probe, 'cost': cost, 'scan': scan}
 
@@ -58,15 +59,20 @@ def update_probe(op, num_gpu, data, psi, scan, probe, num_iter=1):
             num_iter=num_iter,
         )
 
+    if (num_gpu>1):
+        probe = op.asarray_multi(num_gpu, probe)
+        del scan
+        del data
+        print('probe',cost,probe[0].shape, probe[0].tolist())
+    else:
+        print('probe',cost,probe.shape, probe.tolist())
     logger.info('%10s cost is %+12.5e', 'probe', cost)
-    print('test', probe.tolist())
-    exit()
     return probe, cost
 
 
 def update_object(op, num_gpu, data, psi, scan, probe, num_iter=1):
     """Solve the object recovery problem."""
-
+    print('data', data[0].shape)
     def cost_function(psi):
         return op.cost(data, psi, scan, probe)
 

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -30,6 +30,12 @@ def combined(
 
 def update_probe(op, num_gpu, data, psi, scan, probe, num_iter=1):
     """Solve the probe recovery problem."""
+    # TODO: add multi-GPU support
+    if (num_gpu>1):
+        scan, data = op.asarray_multi_fuse(num_gpu, scan, data)
+        psi = psi[0]
+        probe = probe[0]
+
     # TODO: Cache object patche between mode updates
     for m in range(probe.shape[-3]):
 
@@ -53,6 +59,8 @@ def update_probe(op, num_gpu, data, psi, scan, probe, num_iter=1):
         )
 
     logger.info('%10s cost is %+12.5e', 'probe', cost)
+    print('test', probe.tolist())
+    exit()
     return probe, cost
 
 

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -86,6 +86,7 @@ def update_probe(op, num_gpu, data, psi, scan, probe, num_iter=1):
 
 def update_object(op, num_gpu, data, psi, scan, probe, num_iter=1):
     """Solve the object recovery problem."""
+
     def cost_function(psi):
         return op.cost(data, psi, scan, probe)
 

--- a/tests/test_communicator.py
+++ b/tests/test_communicator.py
@@ -3,6 +3,7 @@ import numpy as np
 import unittest
 import pytest
 
+
 @pytest.mark.skip(reason="The communicator module is broken/disabled.")
 class TestMPICommunicator(unittest.TestCase):
     """Test the functions of the MPICommunicator class."""
@@ -19,7 +20,7 @@ class TestMPICommunicator(unittest.TestCase):
         # print("{} ptycho_data:\n{}".format(comm.rank, ptycho_data))
         lo = comm.rank * 3
         np.testing.assert_array_equal(ptycho_data[:, 0:3, :],
-                                      ptycho_data[:, lo:lo+3, :])
+                                      ptycho_data[:, lo:lo + 3, :])
         # Assert the reverse transform works
         tomo_data1 = comm.get_tomo_slice(ptycho_data)
         np.testing.assert_array_equal(tomo_data, tomo_data1)

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -180,7 +180,7 @@ class TestPtychoRecon(unittest.TestCase):
                 **result,
                 data=self.data,
                 algorithm=algorithm,
-                num_gpu=2,
+                num_gpu=1,
                 num_iter=1,
                 # Only works when probe recovery is false because scaling
                 recover_probe=True,

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -175,6 +175,7 @@ class TestPtychoRecon(unittest.TestCase):
         # error0 = self.error_metric(self.error_metric(result['psi']))
         # print('\n', error0)
         for _ in range(5):
+            result['scan'] = self.scan
             result = tike.ptycho.reconstruct(
                 **result,
                 data=self.data,

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -179,7 +179,7 @@ class TestPtychoRecon(unittest.TestCase):
                 **result,
                 data=self.data,
                 algorithm=algorithm,
-                num_gpu=2,
+                num_gpu=1,
                 num_iter=1,
                 # Only works when probe recovery is false because scaling
                 recover_probe=True,

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -179,7 +179,7 @@ class TestPtychoRecon(unittest.TestCase):
                 **result,
                 data=self.data,
                 algorithm=algorithm,
-                num_gpu=1,
+                num_gpu=2,
                 num_iter=1,
                 # Only works when probe recovery is false because scaling
                 recover_probe=True,

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -179,6 +179,7 @@ class TestPtychoRecon(unittest.TestCase):
                 **result,
                 data=self.data,
                 algorithm=algorithm,
+                num_gpu=1,
                 num_iter=1,
                 # Only works when probe recovery is false because scaling
                 recover_probe=True,

--- a/tests/test_tomo.py
+++ b/tests/test_tomo.py
@@ -60,6 +60,7 @@ __docformat__ = 'restructuredtext en'
 
 testdir = os.path.dirname(__file__)
 
+
 @pytest.mark.skip(reason="The tomo module is broken/disabled.")
 class TestPtychoRecon(unittest.TestCase):
     """Test various ptychography reconstruction methods for consistency."""
@@ -72,24 +73,23 @@ class TestPtychoRecon(unittest.TestCase):
         import matplotlib.pyplot as plt
         # Create object
         delta = plt.imread(
-            os.path.join(testdir, "data/Cryptomeria_japonica-0128.tif")
-        )
+            os.path.join(testdir, "data/Cryptomeria_japonica-0128.tif"))
         beta = plt.imread(
-            os.path.join(testdir, "data/Bombus_terrestris-0128.tif")
-        )
+            os.path.join(testdir, "data/Bombus_terrestris-0128.tif"))
         original = np.empty(delta.shape, dtype='complex64')
         original.real = delta / 2550
         original.imag = beta / 2550
         self.original = np.tile(original, (1, 1, 1)).astype('complex64')
         # Define views
-        self.theta = np.linspace(0, np.pi, 201, endpoint=False).astype('float32')
+        self.theta = np.linspace(0, np.pi, 201,
+                                 endpoint=False).astype('float32')
         # Simulate data
         self.data = tike.tomo.simulate(obj=self.original, theta=self.theta)
         setup_data = [
             self.data.astype('complex64'),
             self.theta.astype('float32'),
             self.original.astype('complex64'),
-            ]
+        ]
         with lzma.open(dataset_file, 'wb') as file:
             pickle.dump(setup_data, file)
 
@@ -112,10 +112,10 @@ class TestPtychoRecon(unittest.TestCase):
         theta = xp.array(self.theta)
         original = xp.array(self.original)
         with TomoBackend(
-            ntheta=theta.size,
-            nz=original.shape[0],
-            n=original.shape[1],
-            center=original.shape[1] / 2,
+                ntheta=theta.size,
+                nz=original.shape[0],
+                n=original.shape[1],
+                center=original.shape[1] / 2,
         ) as slv:
             data = slv.fwd(original, theta)
             u1 = slv.adj(data, theta)
@@ -124,7 +124,7 @@ class TestPtychoRecon(unittest.TestCase):
             print()
             print(f"<> = {t1.real.item():06f}{t1.imag.item():+06f}j\n"
                   f"<> = {t2.real.item():06f}{t2.imag.item():+06f}j")
-            xp.testing.assert_allclose(t1, t2,rtol=1e-3)
+            xp.testing.assert_allclose(t1, t2, rtol=1e-3)
 
     def test_consistent_simulate(self):
         """Check tomo.forward for consistency."""
@@ -137,11 +137,11 @@ class TestPtychoRecon(unittest.TestCase):
         When we project at angles 0 and PI/2, the foward operator should be the
         same as taking the sum over the object array along each axis.
         """
-        theta = np.array([0, np.pi/2, np.pi, -np.pi/2], dtype='float32')
+        theta = np.array([0, np.pi / 2, np.pi, -np.pi / 2], dtype='float32')
         size = 11
         original = np.zeros((1, size, size), dtype='complex64')
-        original[0, size//2, :] += 1
-        original[0, :, size//2] += 1j
+        original[0, size // 2, :] += 1
+        original[0, :, size // 2] += 1j
         data = tike.tomo.simulate(original, theta)
         data1 = np.sum(original, axis=1)
         data2 = np.sum(original, axis=2)
@@ -171,6 +171,7 @@ class TestPtychoRecon(unittest.TestCase):
     #             pickle.dump(recon.astype(np.complex64), file)
     #         raise e
     #     np.testing.assert_allclose(recon, standard, rtol=1e-3)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
In this PR, I apply the multi-GPU ptychography design to tike. This new PR allows uneven partitioning of the input data.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Using multi-GPU requires manually spliting&destributing data to devices, creating multiple threads, and binding devices. Since `nscan` parameter is removed, it can now conduct uneven partitioning for the input data. 

Accordingly, each data (e.g., `psi`) becomes a _list_ of `cupy.ndarray`. The size of each _list_ equal to the number of GPU devices. The splitting and distributing happen at `src/tike/ptycho/ptycho.py` and the operators are in `src/tike/operators/cupy/operator.py`.

Our hybrid parallelization model is applied at `src/tike/opt.py`. I apply gather-scatter mode to `dir` computing and all-reduce mode to `line-search` computing.

Creating multiple threads and binding devices happen at `src/tike/operators/cupy/`. Multiple threads are created using `concurrent.futures.ThreadPoolExecutor` in the entry points (i.e., the functions named as `XXX_multi`). Devices are associated using `cupy.cuda.Device` in the device functions (`XXX_device`).

Note: Each device requires an object of RawKernel. So `cp.RawKernel()` is moved into the class functions.

## Issue
The current version cannot support the multi-GPU based probe update. In order to pass the tests, it temporarily gathers the chunks in different GPUs to a single GPU and updates the probe. The multi-GPU probe update should be implemented later.

I've had several trials to keep the uniform functions for the numpy and cupy, but find it is too complicated for the multi-GPU case. In such case, it doesn't simply change `np` to `cp`, but should explicitly assign GPU devices and manage the GPU streams. I preserve the uniform functions as many as possible, but have to write some functions dedicated to multi-GPU. Any code optimizations could be discussed later.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [ ] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Build the documentation successfully
- [ ] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.