### PR TITLE
TST: Time the execution of operators during adjoint tests

### DIFF
--- a/tests/operators/test_convolution.py
+++ b/tests/operators/test_convolution.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import time
 import unittest
 
 import numpy as np
@@ -24,7 +25,6 @@ class TestConvolution(unittest.TestCase):
         self.probe_shape = 15
         self.detector_shape = self.probe_shape * 3
         self.fly = 9
-        print(Convolution)
 
     def test_adjoint(self):
         """Check that the diffraction adjoint operator is correct."""
@@ -51,24 +51,34 @@ class TestConvolution(unittest.TestCase):
             nearplane = op.asarray(nearplane.astype('complex64'))
             kernel = op.asarray(kernel.astype('complex64'))
 
+            start = time.perf_counter()
             d = op.fwd(scan=scan, psi=original, probe=kernel)
+            fwd_time = time.perf_counter() - start
             assert nearplane.shape == d.shape
+            start = time.perf_counter()
             o = op.adj(
                 nearplane=nearplane,
                 scan=scan,
                 probe=kernel,
             )
+            adj_time = time.perf_counter() - start
             assert original.shape == o.shape
+            start = time.perf_counter()
             k = op.adj_probe(
                 scan=scan,
                 psi=original,
                 nearplane=nearplane,
             )
+            adj_prb_time = time.perf_counter() - start
             assert kernel.shape == k.shape
             a = inner_complex(original, o)
             b = inner_complex(d, nearplane)
             c = inner_complex(kernel, k)
             print()
+            print(Convolution)
+            print(f"{fwd_time:1.3e} seconds for fwd")
+            print(f"{adj_time:1.3e} seconds for adj")
+            print(f"{adj_prb_time:1.3e} seconds for adj_prb")
             print('<Q , P*ψ> = {:.6f}{:+.6f}j'.format(a.real.item(),
                                                       a.imag.item()))
             print('<QP,   ψ> = {:.6f}{:+.6f}j'.format(b.real.item(),

--- a/tests/operators/test_lamino.py
+++ b/tests/operators/test_lamino.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import time
 import unittest
 
 import numpy as np
@@ -16,14 +17,13 @@ __docformat__ = 'restructuredtext en'
 class TestLamino(unittest.TestCase):
     """Test the Laminography operator."""
 
-    def setUp(self, n=16, ntheta=8, tilt=np.pi/3, eps=1e-3):
+    def setUp(self, n=16, ntheta=8, tilt=np.pi / 3, eps=1e-3):
         """Load a dataset for reconstruction."""
         self.n = n
         self.ntheta = ntheta
-        self.theta = np.linspace(0, 2*np.pi, ntheta)
+        self.theta = np.linspace(0, 2 * np.pi, ntheta)
         self.tilt = tilt
         self.eps = eps
-        print(Lamino)
 
     def test_adjoint(self):
         """Check that the adjoint operator is correct."""
@@ -35,22 +35,30 @@ class TestLamino(unittest.TestCase):
                 n=self.n,
                 theta=self.theta,
                 tilt=self.tilt,
-                eps=self.eps
+                eps=self.eps,
         ) as op:
 
             obj = op.asarray(obj.astype('complex64'))
             data = op.asarray(data.astype('complex64'))
 
+            start = time.perf_counter()
             d = op.fwd(obj)
+            fwd_time = time.perf_counter() - start
             assert d.shape == data.shape
+            start = time.perf_counter()
             o = op.adj(data)
+            adj_time = time.perf_counter() - start
             assert obj.shape == o.shape
             a = inner_complex(d, data)
             b = inner_complex(obj, o)
+
             print()
+            print(Lamino)
+            print(f"{fwd_time:1.3e} seconds for fwd")
+            print(f"{adj_time:1.3e} seconds for adj")
             print('<Lobj,   data> = {:.6f}{:+.6f}j'.format(
                 a.real.item(), a.imag.item()))
-            print('<obj  , L*data> = {:.6f}{:+.6f}j'.format(
+            print('<obj , L*data> = {:.6f}{:+.6f}j'.format(
                 b.real.item(), b.imag.item()))
             # Test whether Adjoint fixed probe operator is correct
             op.xp.testing.assert_allclose(a.real, b.real, rtol=1e-2)

--- a/tests/operators/test_propagation.py
+++ b/tests/operators/test_propagation.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import time
 import unittest
 
 import numpy as np
@@ -21,7 +22,6 @@ class TestPropagation(unittest.TestCase):
         self.nwaves = 13
         self.probe_shape = 127
         self.detector_shape = self.probe_shape
-        print(Propagation)
 
     def test_adjoint(self):
         """Check that the adjoint operator is correct."""
@@ -39,13 +39,20 @@ class TestPropagation(unittest.TestCase):
             nearplane = op.asarray(nearplane, dtype='complex64')
             farplane = op.asarray(farplane, dtype='complex64')
 
+            start = time.perf_counter()
             f = op.fwd(nearplane=nearplane,)
+            fwd_time = time.perf_counter() - start
             assert f.shape == farplane.shape
+            start = time.perf_counter()
             n = op.adj(farplane=farplane,)
+            adj_time = time.perf_counter() - start
             assert nearplane.shape == n.shape
             a = inner_complex(nearplane, n)
             b = inner_complex(f, farplane)
             print()
+            print(Propagation)
+            print(f"{fwd_time:1.3e} seconds for fwd")
+            print(f"{adj_time:1.3e} seconds for adj")
             print('<ψ , F*Ψ> = {:.6f}{:+.6f}j'.format(a.real.item(),
                                                       a.imag.item()))
             print('<Fψ,   Ψ> = {:.6f}{:+.6f}j'.format(b.real.item(),

--- a/tests/operators/test_ptycho.py
+++ b/tests/operators/test_ptycho.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import time
 import unittest
 
 import numpy as np
@@ -25,7 +26,6 @@ class TestPtycho(unittest.TestCase):
         self.original_shape = (ntheta, 128, 128)
         self.scan_shape = (ntheta, nscan, 2)
         self.fly = fly
-        print(Ptycho)
 
     def test_adjoint(self):
         """Check that the adjoint operator is correct."""
@@ -50,28 +50,39 @@ class TestPtycho(unittest.TestCase):
             farplane = op.asarray(farplane.astype('complex64'))
             scan = op.asarray(scan.astype('float32'))
 
+            start = time.perf_counter()
             d = op.fwd(
                 probe=probe,
                 scan=scan,
                 psi=original,
             )
+            fwd_time = time.perf_counter() - start
             assert d.shape == farplane.shape
+            start = time.perf_counter()
             o = op.adj(
                 farplane=farplane,
                 probe=probe,
                 scan=scan,
             )
+            adj_time = time.perf_counter() - start
             assert original.shape == o.shape
+            start = time.perf_counter()
+            start = time.perf_counter()
             p = op.adj_probe(
                 farplane=farplane,
                 scan=scan,
                 psi=original,
             )
+            adj_prb_time = time.perf_counter() - start
             assert probe.shape == p.shape
             a = inner_complex(d, farplane)
             b = inner_complex(probe, p)
             c = inner_complex(original, o)
             print()
+            print(Ptycho)
+            print(f"{fwd_time:1.3e} seconds for fwd")
+            print(f"{adj_time:1.3e} seconds for adj")
+            print(f"{adj_prb_time:1.3e} seconds for adj_prb")
             print('<FQP,     Ψ> = {:.6f}{:+.6f}j'.format(
                 a.real.item(), a.imag.item()))
             print('<P  , Q*F*Ψ> = {:.6f}{:+.6f}j'.format(

--- a/tests/operators/test_shift.py
+++ b/tests/operators/test_shift.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import time
 import unittest
 
 import numpy as np
@@ -21,7 +22,6 @@ class TestShift(unittest.TestCase):
         self.n = n
         self.nz = nz
         self.ntheta = ntheta
-        print(Shift)
 
     def test_adjoint(self):
         """Check that the adjoint operator is correct."""
@@ -36,7 +36,9 @@ class TestShift(unittest.TestCase):
             original = op.asarray(original, dtype='complex64')
             data = op.asarray(data, dtype='complex64')
 
+            start = time.perf_counter()
             d = op.fwd(original, shift)
+            fwd_time = time.perf_counter() - start
             o = op.fwd(data, -shift)
             original1 = op.fwd(d, -shift)
 
@@ -44,6 +46,8 @@ class TestShift(unittest.TestCase):
             b = inner_complex(original, o)
             e = np.linalg.norm(original - original1) / np.linalg.norm(original)
             print()
+            print(Shift)
+            print(f"{fwd_time:1.3e} seconds for fwd")
             print('<Su,   a> = {:.6f}{:+.6f}j'.format(a.real.item(),
                                                       a.imag.item()))
             print('< u, S*a> = {:.6f}{:+.6f}j'.format(b.real.item(),


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
@nikitinvv wants to know how long it takes for each of the operators to execute.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
I have added walltime markers before and after execution of operators in the adjoint tests. I'm not sure that adding CUDA synchronization points was necessary, so I *did not* include them. The problem sizes for each operator can be adjusted by editing the `setUp()` function of each test. Not sure if it's necessary to allow changing the problem size from the command line.

## Pre-Merge Checklists

### Submitter
- [ ] Write a helpfully descriptive pull request title.
- [ ] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Build the documentation successfully
- [ ] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
