### PR TITLE
MAI: Setup CI with GPU available

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,3 @@
-# Python package
-# Create and test a Python package on multiple Python versions.
-# Add steps that analyze code, save the dist with the build record, publish to
-# a PyPI-compatible index, and more:
-# https://docs.microsoft.com/vsts/pipelines/languages/python
-
-variables:
-  package_name: tike
-
 trigger:
 - master
 
@@ -19,73 +10,31 @@ pr:
     - 'docs/'
     - '/.*'
     - '/*.rst'
+    - '/*.md'
 
 jobs:
 
 - job: Linux
   pool:
-    vmImage: 'ubuntu-latest'
+    name: Default
+    demands:
+    - CUDA_VERSION
+    - Agent.OS -equals Linux
   strategy:
     matrix:
       Python36:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
-        extra.packages: 'pydocstyle'
       Python38:
         python.version: '3.8'
     maxParallel: 4
   steps:
-  - bash: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
-  - bash: >
-      conda install --yes --quiet
-      conda-build
-      $(extra.packages)
-    displayName: Install conda-build
-  - bash: >
-      conda build . --no-anaconda-upload -c conda-forge
-      --python $(python.version)
-    displayName: Conda build
-  # - bash: |
-  #     pydocstyle --match='(?!utils).*\.py' --count -v src/$(package_name)/
-  #   displayName: Run python docstring linter
-  #   condition: eq(variables['python.version'], '3.7')
-
-- job: macOS
-  pool:
-    vmImage: 'macOS-latest'
-  strategy:
-    matrix:
-      Python37:
-        python.version: '3.7'
-    maxParallel: 4
-  steps:
-  - bash: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
-  - bash: sudo chown -R $USER $CONDA
-    displayName: Take ownership of conda installation
-  - bash: >
-      conda install --yes --quiet
-      conda-build
-      $(extra.packages)
-    displayName: Install conda-build
-  - bash: >
-      conda build . --no-anaconda-upload -c conda-forge
-      --python $(python.version)
-    displayName: Conda build
-
-- job: Windows
-  pool:
-    vmImage: 'windows-latest'
-  strategy:
-    matrix:
-      Python37:
-        python.version: '3.7'
-    maxParallel: 4
-  steps:
-  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-    displayName: Add conda to PATH
+  - script: echo "CUDA version is $(CUDA_VERSION)"
+    displayName: Print CUDA version
+  - script: >
+      conda update -n base conda --yes --quiet
+    displayName: Update conda
   - script: >
       conda install --yes --quiet
       conda-build
@@ -93,4 +42,4 @@ jobs:
   - script: >
       conda build . --no-anaconda-upload -c conda-forge
       --python $(python.version)
-    displayName: Conda build
+    displayName: Build with conda-build


### PR DESCRIPTION
Colleagues have convinced me that `tike` should require an NVidia GPU because the value added from being able to run tests without a GPU is not worth the maintenance overhead and confusion(?) caused by supporting two types of operators. Since, the project now has CI with GPU available, the excuse that we need to test without GPU is also no longer valid.

This PR sets up the CI with GPUs available.