### PR TITLE
BUG: Run ptycho.reconstruct on single device with id > 0

### DIFF
--- a/src/tike/pool.py
+++ b/src/tike/pool.py
@@ -10,29 +10,46 @@ import os
 import warnings
 
 import cupy as cp
-import numpy as np
 
 
-class NumPyThreadPool(ThreadPoolExecutor):
+class ThreadPool(ThreadPoolExecutor):
     """Python thread pool plus scatter gather methods.
 
     A Pool is a context manager which provides access to and communications
     amongst workers.
 
+    Attributes
+    ----------
+    workers : int, tuple(int)
+        The number of GPUs to use or a tuple of the device numbers of the GPUs
+        to use. If the number of GPUs is less than the requested number, only
+        workers for the available GPUs are allocated.
     """
 
-    def __init__(self, num_workers: int, device_count=1):
-        super().__init__(num_workers)
-        self.device_count = device_count
-        self.num_workers = num_workers
-        self.workers = list(range(num_workers))
-        self.xp = np
+    def __init__(self, workers):
+        self.device_count = cp.cuda.runtime.getDeviceCount()
+        if type(workers) is int and workers > 0:
+            if workers > self.device_count:
+                warnings.warn(
+                    "Not enough CUDA devices for workers!"
+                    f" Requested {workers} of {self.device_count} devices.")
+                workers = min(workers, self.device_count)
+            workers = tuple(range(workers))
+        else:
+            raise ValueError(f"Provide workers > 0, not {workers}.")
+        for w in workers:
+            if w < 0 or w >= self.device_count:
+                raise ValueError(f'{w} is not a valid GPU device number.')
+        self.workers = workers
+        self.num_workers = len(workers)
+        self.xp = cp
+        super().__init__(self.num_workers)
 
-    def _copy_to(self, x: np.array, worker: int) -> np.array:
-        """Copy x to the given worker."""
-        return self.xp.array(x, copy=True)
+    def _copy_to(self, x, worker: int) -> cp.array:
+        with cp.cuda.Device(worker):
+            return self.xp.asarray(x)
 
-    def bcast(self, x: np.array) -> list:
+    def bcast(self, x: cp.array) -> list:
         """Send a copy of x to all workers."""
 
         def f(worker):
@@ -40,11 +57,7 @@ class NumPyThreadPool(ThreadPoolExecutor):
 
         return list(self.map(f, self.workers))
 
-    # def scatter(self, x: np.array) -> list:
-    #     """Divide x amongst all workers along the 0th dimension."""
-    #     return list(self.map(self._copy_to, x, self.workers))
-
-    def gather(self, x: list, worker=0, axis=0) -> np.array:
+    def gather(self, x: list, worker=0, axis=0) -> cp.array:
         """Concatenate x on a single worker along the given axis."""
         return self.xp.concatenate(
             [self._copy_to(part, worker) for part in x],
@@ -59,21 +72,6 @@ class NumPyThreadPool(ThreadPoolExecutor):
 
         return list(self.map(f, self.workers))
 
-
-class CuPyThreadPool(NumPyThreadPool):
-
-    def __init__(self, num_workers):
-        device_count = cp.cuda.runtime.getDeviceCount()
-        if num_workers > device_count:
-            warnings.warn("Not enough CUDA devices for workers!")
-            num_workers = device_count
-        super().__init__(num_workers, device_count)
-        self.xp = cp
-
-    def _copy_to(self, x: np.array, worker: int) -> np.array:
-        with cp.cuda.Device(worker):
-            return self.xp.asarray(x)
-
     def map(self, func, *iterables, **kwargs):
         """ThreadPoolExecutor.map, but wraps call in a cuda.Device context."""
 
@@ -82,6 +80,3 @@ class CuPyThreadPool(NumPyThreadPool):
                 return func(*args)
 
         return super().map(f, self.workers, *iterables, **kwargs)
-
-
-ThreadPool = CuPyThreadPool

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -150,7 +150,8 @@ def reconstruct(
     rtol : float
         Terminate early if the relative decrease of the cost function is
         less than this amount.
-
+    split : 'grid' or 'stripe'
+        The method to use for splitting the scan positions among GPUS.
     """
     (psi, scan) = get_padded_object(scan, probe) if psi is None else (psi, scan)
     check_allowed_positions(scan, psi, probe)


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
This PR fixes a bug where you cannot set the GPU using `with cupy.cuda.Device()`. The ability to set the GPU for using a single GPU was broken when I merged the single and multi-gpu code paths.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
The ThreadPool class now internally tracks the IDs of the GPUs to be used and when the number of GPUs is set to 1, but the ids are not specified it pulls the current CUDA device through the CuPy API.

With this PR, the ThreadPool class supports setting arbitrary GPUs. However, you cannot set arbitrary GPUs because other portions of the code still have the GPU indexes hardcoded. For example, setting `num_gpu=(0, 1, 2, 3)` is equivalent to `num_gpu=4`. `num_gpu=(4, 5, 6, 7)` should be valid, but because of some hardcoding it will not work.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Build the documentation successfully
- [x] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
