### PR TITLE
BUG: Return floating type from ptycho.simulate()

### DIFF
--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -133,7 +133,7 @@ def simulate(
                     ord=2,
                     axis=2,
                 ))
-        return operator.asnumpy(data)
+        return operator.asnumpy(data.real)
 
 def reconstruct(
         data,


### PR DESCRIPTION
Recent versions of numpy/cupy do not cast complex values to floats
with the square() even though the imaginary part is always zero.
This patch drops the imaginary part before returning from simulate.

<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Build the documentation successfully
- [x] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
