### PR TITLE
CI: Ensure builds on correct python version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,8 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
     maxParallel: 4
   steps:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,14 +46,10 @@ jobs:
       conda create --quiet --force --yes
       -n tike
       --channel conda-forge
+      --file requirements.txt
       pytest
       python=$(python.version)
     displayName: Create build environment
-
-  - script: |
-      source activate tike
-      conda install --file requirements.txt --channel conda-forge --yes --quiet
-    displayName: Install dependencies
 
   - script: conda list -n tike
     displayName: List build environment


### PR DESCRIPTION
I noticed that sometimes the install step resolves to the wrong python version. These changes should ensure that all packages are resolved under the constraint of the desired python version.