### PR TITLE
BUG: Invalid algorithms not caught when matching submodule name

### DIFF
--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -163,7 +163,7 @@ def reconstruct(
     """
     (psi, scan) = get_padded_object(scan, probe) if psi is None else (psi, scan)
     check_allowed_positions(scan, psi, probe)
-    if algorithm in dir(solvers):
+    if algorithm in solvers.__all__:
         # Initialize an operator.
         with Ptycho(
                 probe_shape=probe.shape[-1],
@@ -263,8 +263,8 @@ def reconstruct(
                     result[k] = v[0]
         return {k: operator.asnumpy(v) for k, v in result.items()}
     else:
-        raise ValueError(
-            "The '{}' algorithm is not an available.".format(algorithm))
+        raise ValueError(f"The '{algorithm}' algorithm is not an option.\n"
+                         f"\tAvailable algorithms are : {solvers.__all__}")
 
 
 def _make_mini_batches(data, scan, num_batch, subset_is_random=True):

--- a/src/tike/ptycho/solvers/__init__.py
+++ b/src/tike/ptycho/solvers/__init__.py
@@ -1,4 +1,9 @@
 """Contains different solver implementations."""
 
-from .combined import *
-from .divided import *
+from .combined import cgrad
+from .divided import lstsq_grad
+
+__all__ = [
+    'cgrad',
+    'lstsq_grad',
+]

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -236,6 +236,11 @@ class TestPtychoRecon(unittest.TestCase):
             },
         )
 
+    def test_invaid_algorithm_name(self):
+        """Check that wrong names are handled gracefully."""
+        with self.assertRaises(ValueError):
+            self.template_consistent_algorithm('divided')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The check for invalid algorithm names fails when the algorithm
name matches any object in the solvers namespace. The solution
for this is the check against the contents of an explicitly set
`__all__` parameter which will only ever contain the names of
valid solver functions.

Previously dir(solvers) was used in order to automate the
generation of this list. However, it seems that this is unsafe.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [x] Write tests for new functions or explain why they are not needed.
- [ ] Build the documentation successfully
- [x] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
