### PR TITLE
CI: Ensure that cudatoolkit matches agent cudatoolkit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,6 @@ jobs:
   pool:
     name: Default
     demands:
-    - MultiGPU
     - CUDA_VERSION
     - Agent.OS -equals Linux
   strategy:
@@ -27,10 +26,57 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
-      Python38:
-        python.version: '3.8'
       Python39:
         python.version: '3.9'
+    maxParallel: 4
+  steps:
+
+  - script: echo "CUDA version is $(CUDA_VERSION)"
+    displayName: Print CUDA version
+
+  - script: conda update -n base conda --yes --quiet
+    displayName: Update conda
+
+  - script: conda env remove --yes -n tike
+    displayName: Remove existing build environment
+
+  - script: >
+      conda create --quiet --force --yes
+      -n tike
+      --channel conda-forge
+      --file requirements.txt
+      pytest
+      python=$(python.version)
+      cudatoolkit=$(CUDA_VERSION)
+    displayName: Create build environment
+
+  - script: conda list -n tike
+    displayName: List build environment
+
+  - script: |
+      source activate tike
+      pip install . --no-deps
+    displayName: Setup and install
+
+  - script: |
+      source activate tike
+      pytest -vs
+    displayName: Run tests
+
+  - script: conda clean -py
+
+
+- job: MultiLinux
+  pool:
+    name: Default
+    demands:
+    - MultiGPU
+    - CUDA_VERSION
+    - Agent.OS -equals Linux
+  strategy:
+    matrix:
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
   steps:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,7 @@ jobs:
       --file requirements.txt
       pytest
       python=$(python.version)
+      cudatoolkit=$(CUDA_VERSION)
     displayName: Create build environment
 
   - script: conda list -n tike


### PR DESCRIPTION
Fixing driver incompatibility on CI because cudatoolkit=11 was recently published to conda, but the CI still uses a container with cudatoolkit=10.