### PR TITLE
CI: Try to make CI more robust to file debris

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,11 +37,8 @@ jobs:
   - script: conda update -n base conda --yes --quiet
     displayName: Update conda
 
-  - script: conda env remove --yes -n tike
-    displayName: Remove existing build environment
-
   - script: >
-      conda create --quiet --force --yes
+      conda create --quiet --yes
       -n tike
       --channel conda-forge
       --file requirements.txt
@@ -63,7 +60,7 @@ jobs:
       pytest -vs
     displayName: Run tests
 
-  - script: conda clean -py
+  - script: conda clean --packages --yes
 
 
 - job: MultiLinux
@@ -86,11 +83,8 @@ jobs:
   - script: conda update -n base conda --yes --quiet
     displayName: Update conda
 
-  - script: conda env remove --yes -n tike
-    displayName: Remove existing build environment
-
   - script: >
-      conda create --quiet --force --yes
+      conda create --quiet --yes
       -n tike
       --channel conda-forge
       --file requirements.txt
@@ -112,4 +106,4 @@ jobs:
       pytest -vs
     displayName: Run tests
 
-  - script: conda clean -py
+  - script: conda clean --packages --yes


### PR DESCRIPTION
CI was failing on the step to remove previous environment. Local tests show that this removal step isn't strictly necessary, we can just override an existing environment with `--yes`.