### PR TITLE
CI: Do cleaning elsewhere

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,9 +34,6 @@ jobs:
   - script: echo "CUDA version is $(CUDA_VERSION)"
     displayName: Print CUDA version
 
-  - script: conda update -n base conda --yes --quiet
-    displayName: Update conda
-
   - script: rm /home/azure/conda/envs/tike -rf
     displayName: Force remove previous environments
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,8 +63,6 @@ jobs:
       pytest -vs
     displayName: Run tests
 
-  - script: conda clean --packages --yes
-
 
 - job: MultiLinux
   pool:
@@ -82,9 +80,6 @@ jobs:
 
   - script: echo "CUDA version is $(CUDA_VERSION)"
     displayName: Print CUDA version
-
-  - script: conda update -n base conda --yes --quiet
-    displayName: Update conda
 
   - script: rm /home/azure/conda/envs/tike -rf
     displayName: Force remove previous environments

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,5 +112,3 @@ jobs:
       mpirun -n 2 pytest tests/test_comm.py
       mpirun -n 2 pytest tests/test_ptycho.py -k cgrad
     displayName: Run tests with MPI
-
-  - script: conda clean --packages --yes


### PR DESCRIPTION
Updated workers to automatically clean themselves, so it's not necessary to include in the build steps of the repositories.