### PR TITLE
BUG: Reassign updated eigenprobe batches

### DIFF
--- a/src/tike/opt.py
+++ b/src/tike/opt.py
@@ -27,10 +27,14 @@ def batch_indicies(n, m=1, use_random=False):
     return np.array_split(i, m)
 
 
-def collect_batch(x, b, n):
-    """Returns x[:, b[n]] for use with map()."""
+def get_batch(x, b, n):
+    """Returns x[:, b[n]]; for use with map()."""
     return x[:, b[n]]
 
+
+def put_batch(y, x, b, n):
+    """Assigns y into x[:, b[n]]; for use with map()."""
+    x[:, b[n]] = y
 
 def line_search(
     f,

--- a/src/tike/ptycho/solvers/combined.py
+++ b/src/tike/ptycho/solvers/combined.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 
 from tike.linalg import orthogonalize_gs
-from tike.opt import conjugate_gradient, batch_indicies, collect_batch
+from tike.opt import conjugate_gradient, batch_indicies, get_batch
 from ..position import update_positions_pd
 
 logger = logging.getLogger(__name__)
@@ -40,8 +40,8 @@ def cgrad(
     ]
     for n in range(num_batch):
 
-        bdata = comm.pool.map(collect_batch, data, batches, n=n)
-        bscan = comm.pool.map(collect_batch, scan, batches, n=n)
+        bdata = comm.pool.map(get_batch, data, batches, n=n)
+        bscan = comm.pool.map(get_batch, scan, batches, n=n)
 
         if recover_psi:
             psi, cost = _update_object(
@@ -78,6 +78,7 @@ def cgrad(
                 comm.pool.gather(bscan, axis=1),
             )
             bscan = comm.pool.bcast(bscan)
+            # TODO: Assign bscan into scan when positions are updated
 
     return {'psi': psi, 'probe': probe, 'cost': cost, 'scan': scan}
 

--- a/src/tike/ptycho/solvers/divided.py
+++ b/src/tike/ptycho/solvers/divided.py
@@ -3,7 +3,7 @@ import logging
 import cupy as cp
 
 from tike.linalg import lstsq, projection, norm, orthogonalize_gs
-from tike.opt import batch_indicies, collect_batch
+from tike.opt import batch_indicies, get_batch, put_batch
 
 from ..position import update_positions_pd
 from ..probe import orthogonalize_eig, get_varying_probe, update_eigen_probe
@@ -48,13 +48,16 @@ def lstsq_grad(
     ]
     for n in range(num_batch):
 
-        bdata = comm.pool.map(collect_batch, data, batches, n=n)
-        bscan = comm.pool.map(collect_batch, scan, batches, n=n)
+        bdata = comm.pool.map(get_batch, data, batches, n=n)
+        bscan = comm.pool.map(get_batch, scan, batches, n=n)
 
         if isinstance(eigen_probe, list):
-            beigen_weights = [
-                e[:, b[n]] for b, e in zip(batches, eigen_weights)
-            ]
+            beigen_weights = comm.pool.map(
+                get_batch,
+                eigen_weights,
+                batches,
+                n=n,
+            )
             beigen_probe = eigen_probe
         else:
             beigen_probe = [None] * comm.pool.num_workers
@@ -101,6 +104,15 @@ def lstsq_grad(
         )
 
         # ^--- requires synchronization ---^
+
+        if isinstance(eigen_probe, list):
+            comm.pool.map(
+                put_batch,
+                beigen_weights,
+                eigen_weights,
+                batches,
+                n=n,
+            )
 
     result = {
         'psi': psi,


### PR DESCRIPTION
Because Python memory operators are not always in-place, we must update the array of eigen_weights with new values.