### PR TITLE
NEW: Implement functions for loading Velociprobe raw data

### DIFF
--- a/src/tike/ptycho/io.py
+++ b/src/tike/ptycho/io.py
@@ -144,8 +144,7 @@ def read_aps_2idd(diffraction_path, position_path):
             except OSError as error:
                 warnings.warn(
                     "The HDF5 compression plugin is probably missing. "
-                    "See the conda-forge hdf5-external-filter-plugins package.",
-                )
+                    "See the conda-forge hdf5-external-filter-plugins package.")
                 raise error
 
         data = np.concatenate(data, axis=0)
@@ -154,8 +153,12 @@ def read_aps_2idd(diffraction_path, position_path):
     logging.info(f'Loaded {len(scan)} scan positions.')
 
     if len(data) != len(scan):
-        raise ValueError("The number of positions and frames should be "
-                         f"equal not {data.shape}, {scan.shape}")
+        warnings.warn(
+            f"The number of positions {data.shape} and frames {scan.shape}"
+            " is not equal. One of the two will be truncated.")
+        num_frame = min(len(data), len(scan))
+        scan = scan[:num_frame, ...]
+        data = data[:num_frame, ...]
 
     scan = position_units_to_pixels(
         scan,

--- a/src/tike/ptycho/io.py
+++ b/src/tike/ptycho/io.py
@@ -1,0 +1,38 @@
+__author__ = "Tekin Bicer, Daniel Ching"
+__copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
+
+from tike.constants import wavelength
+
+
+def position_units_to_pixels(
+    positions,
+    detector_distance,
+    detector_pixel_count,
+    detector_pixel_width,
+    photon_energy,
+):
+    """Convert scanning positions units from meters to pixels coordinates.
+
+    Parameters
+    ----------
+    positions : float [m]
+        Coordinates of the position of the beam when frames were collected.
+    detector_distance : float [m]
+        The propagation distance of the beam from the sample to the detector.
+    detector_pixel_count : int
+        The number of pixels across one edge of the detector. Assumes a square
+        detector.
+    detector_pixel_width : float [m]
+        The width of one detector pixel. Assumes square pixels.
+    photon_energy : float [keV]
+        The energy of the incident beam.
+
+    Returns
+    -------
+    positions : float [pixels]
+        The scanning positions in pixel coordinates.
+
+    """
+    return positions * ((detector_pixel_width * detector_pixel_count) /
+                        (detector_distance * wavelength(energy)))
+

--- a/src/tike/ptycho/io.py
+++ b/src/tike/ptycho/io.py
@@ -89,9 +89,9 @@ def read_aps_velociprobe(diffraction_path, position_path):
 
     Returns
     -------
-    data : (..., FRAME, WIDE, HIGH) float32
+    data : (1, FRAME, WIDE, HIGH) float32
         Diffraction patterns; cropped square and peak FFT shifted to corner.
-    scan : (..., POSI, 2) float32
+    scan : (1, POSI, 2) float32
         Scan positions; rescaled to pixel coordinates but uncentered.
 
     """

--- a/src/tike/ptycho/io.py
+++ b/src/tike/ptycho/io.py
@@ -129,7 +129,7 @@ def read_aps_2idd(diffraction_path, position_path):
             data.append(
                 np.fft.ifftshift(
                     x[..., beam_center_y - radius:beam_center_y + radius,
-                      beam_center_x - radius:beam_center_x + radius,],
+                      beam_center_x - radius:beam_center_x + radius],
                     axes=(-2, -1),
                 ))
 

--- a/src/tike/ptycho/io.py
+++ b/src/tike/ptycho/io.py
@@ -46,8 +46,8 @@ def position_units_to_pixels(
         (detector_distance * wavelength(photon_energy / 1000) / 100))
 
 
-def read_aps_2idd(diffraction_path, position_path):
-    """Load ptychography data collected at the Advanced Photon Source 2-ID-D.
+def read_aps_velociprobe(diffraction_path, position_path):
+    """Load ptychography data from the Advanced Photon Source Velociprobe.
 
     Expects one HDF5 file and one CSV file with the following organization
 

--- a/src/tike/ptycho/io.py
+++ b/src/tike/ptycho/io.py
@@ -62,9 +62,9 @@ def read_aps_2idd(diffraction_path, parameter_path):
     Parameters
     ----------
     diffraction_path : string
-        The absolute path to the HDF5 file with diffraction patters
+        The absolute path to the HDF5 file containing diffraction patterns.
     parameter_path : string
-        The absolute path to the HDF5 file with
+        The absolute path to the HDF5 file containing position information.
 
     Returns
     -------

--- a/src/tike/ptycho/io.py
+++ b/src/tike/ptycho/io.py
@@ -37,34 +37,46 @@ def position_units_to_pixels(
                         (detector_distance * wavelength(energy)))
 
 
-def read_aps_2idd(diffraction_path, parameter_path):
-    """Load ptychogrpahy data collected at the Advanced Photon Source 2-ID-D.
+def read_aps_2idd(diffraction_path, position_path):
+    """Load ptychography data collected at the Advanced Photon Source 2-ID-D.
 
-    Expects two HDF5 files with the following organization
+    Expects one HDF5 file and one CSV file with the following organization
 
-    diffraction_path.h5:
-        /df:int[FRAME, WIDE, HIGH] {unit: counts}
-
-    parameter_path.h5:
+    diffraction_path:
         /entry
+            /data
+                /data_000000:int[FRAME, WIDE, HIGH] {unit: counts}
+                /data_000001:int[FRAME, WIDE, HIGH] {unit: counts}
+                ...
             /instrument
                 /detector
+                    /beam_center_x:float            {unit: pixel}
+                    /beam_center_y:float            {unit: pixel}
                     /detectorSpecific
-                        /photon_energy:float {unit: eV}
-                    /detector_distance:float {unit: mm}
-                    /x_pixel_size:float {unit: m}
-                    /beam_center_x:float[POSI] {unit: ?}
-                    /beam_center_y:float[POSI] {unit: ?}
+                        /photon_energy:float        {unit: eV}
+                        /x_pixels_in_detector:int
+                        /y_pixels_in_detector:int
+                    /detector_distance:float        {unit: m}
+                    /x_pixel_size:float             {unit: m}
 
-    Where FRAME is the number of detector frames recorded, POSI is the
-    number of scan positions recorded, WIDE/HIGH is the width and height.
+    Where FRAME is the number of detector frames recorded and WIDE/HIGH is the
+    width and height. The number of data_000000 links may be more than the
+    actual number of files because of some problem where the master file is
+    created before the linked files are created.
+
+    The CSV position raw data file is a 8 column file with columns
+    corresponding to the following parameters: samz, samx, samy, zpx, zpy,
+    encoder y, encoder x, trigger number. However, we don't use this file.
+    Instead we use a preprocessed file with no header and two colums: the
+    horiztonal and vertical positions.
 
     Parameters
     ----------
     diffraction_path : string
-        The absolute path to the HDF5 file containing diffraction patterns.
-    parameter_path : string
-        The absolute path to the HDF5 file containing position information.
+        The absolute path to the HDF5 file containing diffraction patterns and
+        other metadata.
+    position_path : string
+        The absolute path to the CSV file containing position information.
 
     Returns
     -------
@@ -72,25 +84,53 @@ def read_aps_2idd(diffraction_path, parameter_path):
         Diffraction patterns; cropped square and centered on peak.
     scan : (..., POSI, 2) float32
         Scan positions; rescaled to pixel coordinates but uncentered.
+
     """
     import h5py
+
+    scan = np.genfromtxt(position_path, delimiter=",")
 
     with h5py.File(parameter_path, 'r') as f:
         photon_energy = f['/entry/instrument/detector'
                           '/detectorSpecific/photon_energy'][()] / 1000.  # keV
+        detect_width = f['/entry/instrument/detector'
+                         '/detectorSpecific/x_pixels_in_detector'][()]
+        detect_height = f['/entry/instrument/detector'
+                          '/detectorSpecific/y_pixels_in_detector'][()]
         detector_dist = f['/entry/instrument/detector'
-                          '/detector_distance'][()] / 1000.  # meter
+                          '/detector_distance'][()]  # meter
         det_pix_width = f['/entry/instrument/detector'
                           '/x_pixel_size'][()]  # meter
-        scan_coords_x = f['/entry/instrument/detector/beam_center_x'][()]
-        scan_coords_y = f['/entry/instrument/detector/beam_center_y'][()]
+        beam_center_x = f['/entry/instrument/detector/beam_center_x'][()]
+        beam_center_y = f['/entry/instrument/detector/beam_center_y'][()]
 
-    with h5py.File(diffraction_path, 'r') as f:
-        data = f['/dp'][()]
-        # TODO: FFT shift and crop frames to square shape?
+        radius = 256
+        assert beam_center_x + radius < detect_width
+        assert beam_center_y + radius < detect_height
+        assert beam_center_x - radius >= 0
+        assert beam_center_y - radius >= 0
+
+        # TODO: Should be able to predict the number of datasets. However,
+        # let's just catch exception for now.
+        data = []
+
+        def crop_diffraction(x):
+            data.append(x[:, beam_center_x - radius:beam_center_x + radius,
+                          beam_center_y - radius:beam_center_y + radius])
+
+        with h5py.File('fly145_master.h5', 'r') as f:
+            for x in f['/entry/data']:
+                try:
+                    crop_diffraction(f[f'/entry/data/{x}'])
+                except KeyError:
+                    break
+            data = np.concatenate(data, axis=0)
+
+    assert len(data) == len(scan), ("Number of positions and frames should be "
+                                    f"equal not {data.shape}, {scan.shape}")
 
     scan = position_units_to_pixels(
-        np.stack([scan_coords_x, scan_coords_y], axis=1),
+        scan,
         detector_dist,
         data.shape[-1],
         det_pix_width,

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -152,7 +152,7 @@ def simulate(
         if eigen_weights is not None:
             eigen_weights = operator.asarray(eigen_weights, dtype='float32')
         data = _compute_intensity(operator, psi, scan, probe, eigen_weights,
-                                 eigen_probe, fly)
+                                  eigen_probe, fly)
         return operator.asnumpy(data.real)
 
 
@@ -172,7 +172,8 @@ def reconstruct(
     ----------
     data : (..., FRAME, WIDE, HIGH) float32
         The intensity (square of the absolute value) of the propagated
-        wavefront; i.e. what the detector records.
+        wavefront; i.e. what the detector records. FFT-shifted so the
+        diffraction peak is at the corners.
     eigen_probe : (..., 1, EIGEN, SHARED, WIDE, HIGH) complex64
         The eigen probes for all positions.
     eigen_weights : (..., POSI, EIGEN, SHARED) float32


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Implement a function to load data from the APS Velociprobe format.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Uses HDF5 and NumPy to load the diffraction patterns and other parameters from an HDF5 file and some preprocessed scanning positions from a CSV file.

From my tests of fly-scan data from 2019-2, it seems that often the number of scanning positions *does not match* the number of frame collected. Thus, I truncate the data to the shorter of the two lengths.

I tested multiple datasets from different runs: RAVEN_IC RAVEN_pillar, and XBIC and was able to see reconstructions.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [x] Write tests for new functions or explain why they are not needed.
- [ ] Build the documentation successfully
- [x] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
