### PR TITLE
REF: Replace deprecated pkg_resources with importlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cupy>=7
 mpi4py>=3
-importlib_resources
+importlib_resources # backport for python<3.7
+importlib_metadata # backport for python<3.8
 matplotlib-base
 numpy>=1.17
 python>=3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cupy>=7
 mpi4py>=3
-importlib_resources # backport for python<3.7
+importlib_resources # backport for python<3.9
 importlib_metadata # backport for python<3.8
 matplotlib-base
 numpy>=1.17

--- a/src/tike/__init__.py
+++ b/src/tike/__init__.py
@@ -57,14 +57,14 @@ License
 The software is licensed under the BSD-3 license.
 
 """
-
+# Backport to python<3.8 available as importlib_metadata package
+from importlib.metadata import version, PackageNotFoundError
 import logging
-from pkg_resources import get_distribution, DistributionNotFound
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version('tike')
+except PackageNotFoundError:
     # package is not installed
     pass

--- a/src/tike/__init__.py
+++ b/src/tike/__init__.py
@@ -57,8 +57,11 @@ License
 The software is licensed under the BSD-3 license.
 
 """
-# Backport to python<3.8 available as importlib_metadata package
-from importlib.metadata import version, PackageNotFoundError
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ModuleNotFoundError:
+    # Backport to python<3.8 available as importlib_metadata package
+    from importlib_metadata import version, PackageNotFoundError
 import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/tike/__init__.py
+++ b/src/tike/__init__.py
@@ -59,7 +59,7 @@ The software is licensed under the BSD-3 license.
 """
 try:
     from importlib.metadata import version, PackageNotFoundError
-except ModuleNotFoundError:
+except ImportError:
     # Backport to python<3.8 available as importlib_metadata package
     from importlib_metadata import version, PackageNotFoundError
 import logging

--- a/src/tike/operators/cupy/bucket.py
+++ b/src/tike/operators/cupy/bucket.py
@@ -1,7 +1,7 @@
 __author__ = "Daniel Ching, Xiaodong Yu"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
-from importlib_resources import files
+from importlib.resources import files
 from itertools import product
 import logging
 

--- a/src/tike/operators/cupy/bucket.py
+++ b/src/tike/operators/cupy/bucket.py
@@ -3,7 +3,7 @@ __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
 try:
     from importlib.resources import files
-except ModuleNotFoundError:
+except ImportError:
     # Backport for python<3.9 available as importlib_resources package
     from importlib_resources import files
 from itertools import product

--- a/src/tike/operators/cupy/bucket.py
+++ b/src/tike/operators/cupy/bucket.py
@@ -1,7 +1,11 @@
 __author__ = "Daniel Ching, Xiaodong Yu"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
-from importlib.resources import files
+try:
+    from importlib.resources import files
+except ModuleNotFoundError:
+    # Backport for python<3.9 available as importlib_resources package
+    from importlib_resources import files
 from itertools import product
 import logging
 

--- a/src/tike/operators/cupy/flow.py
+++ b/src/tike/operators/cupy/flow.py
@@ -4,7 +4,7 @@ __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 import cupy as cp
 try:
     from importlib.resources import files
-except ModuleNotFoundError:
+except ImportError:
     # Backport for python<3.9 available as importlib_resources package
     from importlib_resources import files
 

--- a/src/tike/operators/cupy/flow.py
+++ b/src/tike/operators/cupy/flow.py
@@ -2,7 +2,11 @@ __author__ = "Daniel Ching, Viktor Nikitin"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
 import cupy as cp
-from importlib.resources import files
+try:
+    from importlib.resources import files
+except ModuleNotFoundError:
+    # Backport for python<3.9 available as importlib_resources package
+    from importlib_resources import files
 
 from .operator import Operator
 

--- a/src/tike/operators/cupy/flow.py
+++ b/src/tike/operators/cupy/flow.py
@@ -2,7 +2,7 @@ __author__ = "Daniel Ching, Viktor Nikitin"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
 import cupy as cp
-from importlib_resources import files
+from importlib.resources import files
 
 from .operator import Operator
 

--- a/src/tike/operators/cupy/lamino.py
+++ b/src/tike/operators/cupy/lamino.py
@@ -3,7 +3,7 @@ __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
 try:
     from importlib.resources import files
-except ModuleNotFoundError:
+except ImportError:
     # Backport for python<3.9 available as importlib_resources package
     from importlib_resources import files
 

--- a/src/tike/operators/cupy/lamino.py
+++ b/src/tike/operators/cupy/lamino.py
@@ -1,7 +1,11 @@
 __author__ = "Daniel Ching, Viktor Nikitin"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
-from importlib.resources import files
+try:
+    from importlib.resources import files
+except ModuleNotFoundError:
+    # Backport for python<3.9 available as importlib_resources package
+    from importlib_resources import files
 
 import cupy as cp
 import numpy as np

--- a/src/tike/operators/cupy/lamino.py
+++ b/src/tike/operators/cupy/lamino.py
@@ -1,7 +1,7 @@
 __author__ = "Daniel Ching, Viktor Nikitin"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
-from importlib_resources import files
+from importlib.resources import files
 
 import cupy as cp
 import numpy as np

--- a/src/tike/operators/cupy/patch.py
+++ b/src/tike/operators/cupy/patch.py
@@ -3,7 +3,7 @@ __copyright__ = "Copyright (c) 2021, UChicago Argonne, LLC."
 
 try:
     from importlib.resources import files
-except ModuleNotFoundError:
+except ImportError:
     # Backport for python<3.9 available as importlib_resources package
     from importlib_resources import files
 

--- a/src/tike/operators/cupy/patch.py
+++ b/src/tike/operators/cupy/patch.py
@@ -1,7 +1,11 @@
 __author__ = "Daniel Ching"
 __copyright__ = "Copyright (c) 2021, UChicago Argonne, LLC."
 
-from importlib.resources import files
+try:
+    from importlib.resources import files
+except ModuleNotFoundError:
+    # Backport for python<3.9 available as importlib_resources package
+    from importlib_resources import files
 
 import cupy as cp
 import numpy as np

--- a/src/tike/operators/cupy/patch.py
+++ b/src/tike/operators/cupy/patch.py
@@ -1,7 +1,7 @@
 __author__ = "Daniel Ching"
 __copyright__ = "Copyright (c) 2021, UChicago Argonne, LLC."
 
-from importlib_resources import files
+from importlib.resources import files
 
 import cupy as cp
 import numpy as np

--- a/src/tike/operators/cupy/usfft.py
+++ b/src/tike/operators/cupy/usfft.py
@@ -10,7 +10,7 @@ operations: zero-padding, interpolation-kernel-correction, FFT, and
 linear-interpolation.
 """
 import cupy as cp
-from importlib_resources import files
+from importlib.resources import files
 
 _cu_source = files('tike.operators.cupy').joinpath('usfft.cu').read_text()
 

--- a/src/tike/operators/cupy/usfft.py
+++ b/src/tike/operators/cupy/usfft.py
@@ -10,7 +10,11 @@ operations: zero-padding, interpolation-kernel-correction, FFT, and
 linear-interpolation.
 """
 import cupy as cp
-from importlib.resources import files
+try:
+    from importlib.resources import files
+except ModuleNotFoundError:
+    # Backport for python<3.9 available as importlib_resources package
+    from importlib_resources import files
 
 _cu_source = files('tike.operators.cupy').joinpath('usfft.cu').read_text()
 

--- a/src/tike/operators/cupy/usfft.py
+++ b/src/tike/operators/cupy/usfft.py
@@ -12,7 +12,7 @@ linear-interpolation.
 import cupy as cp
 try:
     from importlib.resources import files
-except ModuleNotFoundError:
+except ImportError:
     # Backport for python<3.9 available as importlib_resources package
     from importlib_resources import files
 


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
pkg_resources from setuptools is deprecated. Moving uses to importlib using backport libraries for pythons<3.8.
## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Using importlib to replace pkg_resources as recommended by setuptools docs.
## Pre-Merge Checklists

### Submitter
- [ ] Write a helpfully descriptive pull request title.
- [ ] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Build the documentation successfully
- [ ] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
