### PR TITLE
API: Remove unused parameters from ptycho.solvers

### DIFF
--- a/docs/source/api/ptycho.solvers.rst
+++ b/docs/source/api/ptycho.solvers.rst
@@ -10,5 +10,7 @@ solvers
       :nosignatures:
       :recursive:
 
+      adam_grad
+      epie
       cgrad
       lstsq_grad

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -272,18 +272,18 @@ def reconstruct(
                     initial_scan,
                 )
                 result = {
-                    'psi':
-                        comm.pool.bcast([psi.astype('complex64')]),
-                    'probe':
-                        comm.pool.bcast([probe.astype('complex64')]),
-                    'eigen_probe':
-                        comm.pool.bcast([eigen_probe.astype('complex64')])
-                        if eigen_probe is not None else None,
-                    'scan':
-                        scan,
-                    'eigen_weights':
-                        eigen_weights,
+                    'psi': comm.pool.bcast([psi.astype('complex64')]),
+                    'probe': comm.pool.bcast([probe.astype('complex64')]),
+                    'scan': scan,
                 }
+                if eigen_probe is not None:
+                    result.update({
+                        'eigen_probe':
+                            comm.pool.bcast([eigen_probe.astype('complex64')])
+                            if eigen_probe is not None else None,
+                        'eigen_weights':
+                            eigen_weights,
+                    })
                 if position_options:
                     result['position_options'] = [
                         position_options.split(x) for x in order
@@ -344,7 +344,6 @@ def reconstruct(
                         operator,
                         comm,
                         data=data,
-                        num_batch=num_batch,
                         batches=batches,
                         **kwargs,
                     )

--- a/src/tike/ptycho/solvers/__init__.py
+++ b/src/tike/ptycho/solvers/__init__.py
@@ -7,7 +7,7 @@ from .epie import epie
 
 __all__ = [
     'adam_grad',
+    'epie',
     'cgrad',
     'lstsq_grad',
-    'epie',
 ]

--- a/src/tike/ptycho/solvers/__init__.py
+++ b/src/tike/ptycho/solvers/__init__.py
@@ -1,8 +1,8 @@
 """Contains different solver implementations."""
 
 from .adam import adam_grad
-from .combined import cgrad
-from .divided import lstsq_grad
+from .conjugate import cgrad
+from .lstsq import lstsq_grad
 from .epie import epie
 
 __all__ = [

--- a/src/tike/ptycho/solvers/adam.py
+++ b/src/tike/ptycho/solvers/adam.py
@@ -1,7 +1,6 @@
 import logging
 
 import cupy as cp
-import numpy as np
 
 from tike.linalg import orthogonalize_gs
 from tike.opt import get_batch, adam, randomizer
@@ -14,15 +13,11 @@ logger = logging.getLogger(__name__)
 def adam_grad(
     op, comm,
     data, probe, scan, psi,
-    cost=None,
-    eigen_probe=None,
-    eigen_weights=None,
-    num_batch=1,
-    subset_is_random=True,
+    batches,
     probe_options=None,
     position_options=None,
     object_options=None,
-    batches=None,
+    cost=None,
 ):  # yapf: disable
     """Solve the ptychography problem using ADAptive Moment gradient descent.
 
@@ -38,8 +33,7 @@ def adam_grad(
     .. seealso:: :py:mod:`tike.ptycho`
 
     """
-    cost = np.inf
-    for n in randomizer.permutation(num_batch):
+    for n in randomizer.permutation(len(batches[0])):
 
         bdata = comm.pool.map(get_batch, data, batches, n=n)
         bscan = comm.pool.map(get_batch, scan, batches, n=n)

--- a/src/tike/ptycho/solvers/adam.py
+++ b/src/tike/ptycho/solvers/adam.py
@@ -11,14 +11,18 @@ logger = logging.getLogger(__name__)
 
 
 def adam_grad(
-    op, comm,
-    data, probe, scan, psi,
+    op,
+    comm,
+    data,
+    probe,
+    scan,
+    psi,
     batches,
     probe_options=None,
     position_options=None,
     object_options=None,
     cost=None,
-):  # yapf: disable
+):
     """Solve the ptychography problem using ADAptive Moment gradient descent.
 
     Parameters
@@ -26,8 +30,40 @@ def adam_grad(
     op : :py:class:`tike.operators.Ptycho`
         A ptychography operator.
     comm : :py:class:`tike.communicators.Comm`
-        An object which manages communications between both
-        GPUs and nodes.
+        An object which manages communications between GPUs and nodes.
+    data : list((FRAME, WIDE, HIGH) float32, ...)
+        A list of unique CuPy arrays for each device containing
+        the intensity (square of the absolute value) of the propagated
+        wavefront; i.e. what the detector records. FFT-shifted so the
+        diffraction peak is at the corners.
+    probe : list((1, 1, SHARED, WIDE, HIGH) complex64, ...)
+        A list of duplicate CuPy arrays for each device containing
+        the shared complex illumination function amongst all positions.
+    scan : list((POSI, 2) float32, ...)
+        A list of unique CuPy arrays for each device containing
+        coordinates of the minimum corner of the probe grid for each
+        measurement in the coordinate system of psi. Coordinate order
+        consistent with WIDE, HIGH order.
+    psi : list((WIDE, HIGH) complex64, ...)
+        A list of duplicate CuPy arrays for each device containing
+        the wavefront modulation coefficients of the object.
+    batches : list(list((BATCH_SIZE, ) int, ...), ...)
+        A list of list of indices along the FRAME axis of `data` for
+        each device which define the batches of `data` to process
+        simultaneously.
+    position_options : :py:class:`tike.ptycho.PositionOptions`
+        A class containing settings related to position correction.
+    probe_options : :py:class:`tike.ptycho.ProbeOptions`
+        A class containing settings related to probe updates.
+    object_options : :py:class:`tike.ptycho.ObjectOptions`
+        A class containing settings related to object updates.
+    cost : float
+        The current objective function value.
+
+    Returns
+    -------
+    result : dict
+        A dictionary containing the updated inputs if they can be updated.
 
 
     .. seealso:: :py:mod:`tike.ptycho`

--- a/src/tike/ptycho/solvers/conjugate.py
+++ b/src/tike/ptycho/solvers/conjugate.py
@@ -1,7 +1,5 @@
 import logging
 
-import numpy as np
-
 from tike.linalg import orthogonalize_gs
 from tike.opt import conjugate_gradient, get_batch, randomizer
 from ..position import update_positions_pd, PositionOptions
@@ -13,17 +11,13 @@ logger = logging.getLogger(__name__)
 def cgrad(
     op, comm,
     data, probe, scan, psi,
+    batches,
     cg_iter=4,
-    cost=None,
-    eigen_probe=None,
-    eigen_weights=None,
-    num_batch=1,
-    subset_is_random=True,
     step_length=1,
     probe_options=None,
     position_options=None,
     object_options=None,
-    batches=None,
+    cost=None,
 ):  # yapf: disable
     """Solve the ptychography problem using conjugate gradient.
 
@@ -39,7 +33,7 @@ def cgrad(
     .. seealso:: :py:mod:`tike.ptycho`
 
     """
-    for n in randomizer.permutation(num_batch):
+    for n in randomizer.permutation(len(batches[0])):
 
         bdata = comm.pool.map(get_batch, data, batches, n=n)
         bscan = comm.pool.map(get_batch, scan, batches, n=n)

--- a/src/tike/ptycho/solvers/epie.py
+++ b/src/tike/ptycho/solvers/epie.py
@@ -14,16 +14,11 @@ logger = logging.getLogger(__name__)
 def epie(
     op, comm,
     data, probe, scan, psi,
-    cg_iter=4,
-    cost=None,
-    eigen_probe=None,
-    eigen_weights=None,
-    num_batch=1,
-    subset_is_random=True,
+    batches,
     probe_options=None,
     position_options=None,
     object_options=None,
-    batches=None,
+    cost=None,
 ):  # yapf: disable
     """Solve the ptychography problem using extended ptychographical engine.
 
@@ -34,7 +29,7 @@ def epie(
     Ultramicroscopy 109 (10): 1256–62.
     https://doi.org/10.1016/j.ultramic.2009.05.012.
     """
-    for n in randomizer.permutation(num_batch):
+    for n in randomizer.permutation(len(batches[0])):
 
         bdata = comm.pool.map(get_batch, data, batches, n=n)
         bscan = comm.pool.map(get_batch, scan, batches, n=n)

--- a/src/tike/ptycho/solvers/epie.py
+++ b/src/tike/ptycho/solvers/epie.py
@@ -12,15 +12,59 @@ logger = logging.getLogger(__name__)
 
 
 def epie(
-    op, comm,
-    data, probe, scan, psi,
+    op,
+    comm,
+    data,
+    probe,
+    scan,
+    psi,
     batches,
     probe_options=None,
     position_options=None,
     object_options=None,
     cost=None,
-):  # yapf: disable
+):
     """Solve the ptychography problem using extended ptychographical engine.
+
+    Parameters
+    ----------
+    op : :py:class:`tike.operators.Ptycho`
+        A ptychography operator.
+    comm : :py:class:`tike.communicators.Comm`
+        An object which manages communications between GPUs and nodes.
+    data : list((FRAME, WIDE, HIGH) float32, ...)
+        A list of unique CuPy arrays for each device containing
+        the intensity (square of the absolute value) of the propagated
+        wavefront; i.e. what the detector records. FFT-shifted so the
+        diffraction peak is at the corners.
+    probe : list((1, 1, SHARED, WIDE, HIGH) complex64, ...)
+        A list of duplicate CuPy arrays for each device containing
+        the shared complex illumination function amongst all positions.
+    scan : list((POSI, 2) float32, ...)
+        A list of unique CuPy arrays for each device containing
+        coordinates of the minimum corner of the probe grid for each
+        measurement in the coordinate system of psi. Coordinate order
+        consistent with WIDE, HIGH order.
+    psi : list((WIDE, HIGH) complex64, ...)
+        A list of duplicate CuPy arrays for each device containing
+        the wavefront modulation coefficients of the object.
+    batches : list(list((BATCH_SIZE, ) int, ...), ...)
+        A list of list of indices along the FRAME axis of `data` for
+        each device which define the batches of `data` to process
+        simultaneously.
+    position_options : :py:class:`tike.ptycho.PositionOptions`
+        A class containing settings related to position correction.
+    probe_options : :py:class:`tike.ptycho.ProbeOptions`
+        A class containing settings related to probe updates.
+    object_options : :py:class:`tike.ptycho.ObjectOptions`
+        A class containing settings related to object updates.
+    cost : float
+        The current objective function value.
+
+    Returns
+    -------
+    result : dict
+        A dictionary containing the updated inputs if they can be updated.
 
     References
     ----------
@@ -28,6 +72,9 @@ def epie(
     Ptychographical Phase Retrieval Algorithm for Diffractive Imaging.”
     Ultramicroscopy 109 (10): 1256–62.
     https://doi.org/10.1016/j.ultramic.2009.05.012.
+
+    .. seealso:: :py:mod:`tike.ptycho`
+
     """
     for n in randomizer.permutation(len(batches[0])):
 

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -1,7 +1,6 @@
 import logging
 
 import cupy as cp
-from numpy.typing import NDArray
 
 import tike.communicators
 from tike.linalg import projection, norm, orthogonalize_gs
@@ -19,11 +18,11 @@ logger = logging.getLogger(__name__)
 def lstsq_grad(
     op: tike.operators.Ptycho,
     comm: tike.communicators.Comm,
-    data: list[NDArray[cp.float32]],
-    probe: list[NDArray[cp.complex64]],
-    scan: list[NDArray[cp.float32]],
-    psi: list[NDArray[cp.complex64]],
-    batches: list[NDArray[cp.int]],
+    data: list,
+    probe: list,
+    scan: list,
+    psi: list,
+    batches: list[list],
     eigen_probe=None,
     eigen_weights=None,
     probe_options=None,

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -16,16 +16,13 @@ logger = logging.getLogger(__name__)
 def lstsq_grad(
     op, comm,
     data, probe, scan, psi,
-    cg_iter=4,
-    cost=None,
+    batches,
     eigen_probe=None,
     eigen_weights=None,
-    num_batch=1,
-    subset_is_random=True,
     probe_options=None,
     position_options=None,
     object_options=None,
-    batches=None,
+    cost=None,
 ):  # yapf: disable
     """Solve the ptychography problem using Odstrcil et al's approach.
 
@@ -47,7 +44,7 @@ def lstsq_grad(
 
     """
 
-    for n in randomizer.permutation(num_batch):
+    for n in randomizer.permutation(len(batches[0])):
 
         bdata = comm.pool.map(get_batch, data, batches, n=n)
         bscan = comm.pool.map(get_batch, scan, batches, n=n)

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -26,8 +26,8 @@ def lstsq_grad(
 ):  # yapf: disable
     """Solve the ptychography problem using Odstrcil et al's approach.
 
-    The near- and farfield- ptychography problems are solved separately using
-    gradient descent in the farfield and linear-least-squares in the nearfield.
+    Object and probe are updated simultaneouly using optimal step sizes
+    computed using a least squares approach.
 
     Parameters
     ----------
@@ -35,6 +35,36 @@ def lstsq_grad(
         A ptychography operator.
     comm : tike.communicators.Comm
         An object which manages communications between GPUs and nodes.
+    data : list((FRAME, WIDE, HIGH) float32, ...)
+        A list of unique CuPy arrays for each device containing
+        the intensity (square of the absolute value) of the propagated
+        wavefront; i.e. what the detector records. FFT-shifted so the
+        diffraction peak is at the corners.
+    eigen_probe : list((EIGEN, SHARED, WIDE, HIGH) complex64, ...)
+        A list of duplicate CuPy arrays for each device containing
+        the eigen probes for all positions.
+    eigen_weights : list((POSI, EIGEN, SHARED) float32, ...)
+        A list of unique CuPy arrays for each device containing
+        the relative intensity of the eigen probes at each position.
+    psi : list((WIDE, HIGH) complex64, ...)
+        A list of duplicate CuPy arrays for each device containing
+        the wavefront modulation coefficients of the object.
+    probe : list((1, 1, SHARED, WIDE, HIGH) complex64, ...)
+        A list of duplicate CuPy arrays for each device containing
+        the shared complex illumination function amongst all positions.
+    scan : list((POSI, 2) float32, ...)
+        A list of unique CuPy arrays for each device containing
+        coordinates of the minimum corner of the probe grid for each
+        measurement in the coordinate system of psi. Coordinate order
+        consistent with WIDE, HIGH order.
+    position_options : PositionOptions
+        A class containing settings related to position correction.
+    probe_options : ProbeOptions
+        A class containing settings related to probe updates.
+    object_options : ObjectOptions
+        A class containing settings related to object updates.
+    cost : float
+        The current objective function value.
 
     References
     ----------

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -29,7 +29,7 @@ def lstsq_grad(
     position_options=None,
     object_options=None,
     cost=None,
-):
+) -> dict:
     """Solve the ptychography problem using Odstrcil et al's approach.
 
     Object and probe are updated simultaneouly using optimal step sizes
@@ -75,6 +75,11 @@ def lstsq_grad(
         A class containing settings related to object updates.
     cost : float
         The current objective function value.
+
+    Returns
+    -------
+    result : dict
+        A dictionary containing the updated inputs if they can be updated.
 
     References
     ----------

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -65,11 +65,11 @@ def lstsq_grad(
     eigen_weights : list((POSI, EIGEN, SHARED) float32, ...)
         A list of unique CuPy arrays for each device containing
         the relative intensity of the eigen probes at each position.
-    position_options : tike.ptycho.PositionOptions
+    position_options : :py:class:`tike.ptycho.PositionOptions`
         A class containing settings related to position correction.
-    probe_options : tike.ptycho.ProbeOptions
+    probe_options : :py:class:`tike.ptycho.ProbeOptions`
         A class containing settings related to probe updates.
-    object_options : tike.ptycho.ObjectOptions
+    object_options : :py:class:`tike.ptycho.ObjectOptions`
         A class containing settings related to object updates.
     cost : float
         The current objective function value.

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -85,6 +85,8 @@ def lstsq_grad(
     least-squares solver for generalized maximum-likelihood ptychography.
     Optics Express. 2018.
 
+    .. seealso:: :py:mod:`tike.ptycho`
+
     """
 
     for n in randomizer.permutation(len(batches[0])):

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -2,9 +2,7 @@ import logging
 
 import cupy as cp
 
-import tike.communicators
 from tike.linalg import projection, norm, orthogonalize_gs
-import tike.operators
 from tike.opt import randomizer, get_batch, put_batch, adam
 
 from ..position import PositionOptions, update_positions_pd, _image_grad
@@ -16,20 +14,20 @@ logger = logging.getLogger(__name__)
 
 
 def lstsq_grad(
-    op: tike.operators.Ptycho,
-    comm: tike.communicators.Comm,
-    data: list,
-    probe: list,
-    scan: list,
-    psi: list,
-    batches: list[list],
+    op,
+    comm,
+    data,
+    probe,
+    scan,
+    psi,
+    batches,
     eigen_probe=None,
     eigen_weights=None,
     probe_options=None,
     position_options=None,
     object_options=None,
     cost=None,
-) -> dict:
+):
     """Solve the ptychography problem using Odstrcil et al's approach.
 
     Object and probe are updated simultaneouly using optimal step sizes
@@ -37,9 +35,9 @@ def lstsq_grad(
 
     Parameters
     ----------
-    op : tike.operators.Ptycho
+    op : :py:class:`tike.operators.Ptycho`
         A ptychography operator.
-    comm : tike.communicators.Comm
+    comm : :py:class:`tike.communicators.Comm`
         An object which manages communications between GPUs and nodes.
     data : list((FRAME, WIDE, HIGH) float32, ...)
         A list of unique CuPy arrays for each device containing

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -283,8 +283,6 @@ class TestPtychoRecon(unittest.TestCase):
             self.template_consistent_algorithm(
                 'adam_grad',
                 params={
-                    'subset_is_random':
-                        True,
                     'batch_size':
                         int(self.data.shape[-3] / 3),
                     'num_gpu':
@@ -307,7 +305,6 @@ class TestPtychoRecon(unittest.TestCase):
             self.template_consistent_algorithm(
                 'cgrad',
                 params={
-                    'subset_is_random': True,
                     'batch_size': int(self.data.shape[-3] / 3),
                     'num_gpu': 2,
                     'probe_options': ProbeOptions(),
@@ -322,8 +319,6 @@ class TestPtychoRecon(unittest.TestCase):
             self.template_consistent_algorithm(
                 'lstsq_grad',
                 params={
-                    'subset_is_random':
-                        True,
                     'batch_size':
                         int(self.data.shape[-3] / 3),
                     'num_gpu':
@@ -352,8 +347,6 @@ class TestPtychoRecon(unittest.TestCase):
             self.template_consistent_algorithm(
                 'lstsq_grad',
                 params={
-                    'subset_is_random':
-                        True,
                     'batch_size':
                         int(self.data.shape[-3] / 3),
                     'num_gpu':


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Before refactoring the tike.ptycho.reconstruct API and related functions, I thought it would be good to clean-up and harden the tike.ptycho.solvers API. This serves the purpose of allowing parallel works on the internals of the solvers and the setup/teardown machinery that manages these solvers with less mystery about whether something will break.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Removed parameters from functions in ptycho.solvers that are unused. This also means that each function should not longer be passed any parameters that it doesn't use.

Add documentation strings that explain all of the parameters.

@stevehenke, I only filled out the docstrings for the ptycho.solvers.lstsq_grad method. If they seem understandable, then I will copy them to the other functions in the module.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [x] Write tests for new functions or explain why they are not needed.
- [x] Build the documentation successfully
- [x] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [x] Actually read all of the code.