### PR TITLE
NEW: Perform ptycho adjoints for probe and obj simultaneously

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
     displayName: Force remove previous environments
 
   - script: >
-      conda create --quiet --yes
+      mamba create --quiet --yes
       -n tike
       --channel conda-forge
       --file requirements.txt
@@ -88,7 +88,7 @@ jobs:
     displayName: Force remove previous environments
 
   - script: >
-      conda create --quiet --yes
+      mamba create --quiet --yes
       -n tike
       --channel conda-forge
       --file requirements.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,6 +112,7 @@ jobs:
 
   - script: |
       source activate tike
+      export OMPI_MCA_opal_cuda_support=true
       mpirun -n 2 pytest tests/test_comm.py -vs
       mpirun -n 2 pytest tests/test_ptycho.py -k TestPtychoRecon -vs
       mpirun -n 2 pytest tests/test_lamino.py -k bucket -vs

--- a/src/tike/operators/cupy/convolution.py
+++ b/src/tike/operators/cupy/convolution.py
@@ -124,7 +124,7 @@ class Convolution(Operator):
         patches *= nearplane[..., self.pad:self.end, self.pad:self.end]
         return patches
 
-    def adj_both(self, nearplane, scan, probe, psi, overwrite=False):
+    def adj_all(self, nearplane, scan, probe, psi, overwrite=False):
         """Peform adj and adj_probe at the same time."""
         assert probe.shape[:-4] == scan.shape[:-2]
         assert psi.shape[:-2] == scan.shape[:-2], (psi.shape, scan.shape)

--- a/src/tike/operators/cupy/ptycho.py
+++ b/src/tike/operators/cupy/ptycho.py
@@ -47,11 +47,18 @@ class Ptycho(Operator):
 
     """
 
-    def __init__(self, detector_shape, probe_shape, nz, n,
-                 ntheta=1, model='gaussian',
-                 propagation=Propagation,
-                 diffraction=Convolution,
-                 **kwargs):  # noqa: D102 yapf: disable
+    def __init__(
+        self,
+        detector_shape,
+        probe_shape,
+        nz,
+        n,
+        ntheta=1,
+        model='gaussian',
+        propagation=Propagation,
+        diffraction=Convolution,
+        **kwargs,
+    ):
         """Please see help(Ptycho) for more info."""
         self.propagation = propagation(
             detector_shape=detector_shape,
@@ -63,7 +70,6 @@ class Ptycho(Operator):
             detector_shape=detector_shape,
             nz=nz,
             n=n,
-            model=model,
             **kwargs,
         )
         # TODO: Replace these with @property functions
@@ -177,3 +183,17 @@ class Ptycho(Operator):
             axis=0,
             keepdims=True,
         )
+
+    def adj_all(self, farplane, probe, scan, psi, overwrite=False):
+        """Please see help(Ptycho) for more info."""
+        apsi, aprobe = self.diffraction.adj_all(
+            nearplane=self.propagation.adj(
+                farplane,
+                overwrite=overwrite,
+            )[..., 0, :, :, :],
+            probe=probe[..., 0, :, :, :],
+            scan=scan,
+            overwrite=True,
+            psi=psi,
+        )
+        return apsi, aprobe[..., None, :, :, :]

--- a/src/tike/ptycho/solvers/divided.py
+++ b/src/tike/ptycho/solvers/divided.py
@@ -487,25 +487,7 @@ def _update_nearplane(op, comm, nearplane, psi, scan_, probe, unique_probe,
 
 def _update_wavefront(data, varying_probe, scan, psi, op):
 
-    # Compute the diffraction patterns for all of the probe modes at once.
-    # We need access to all of the modes of a position to solve the phase
-    # problem. The Ptycho operator doesn't do this natively, so it's messy.
-    patches = cp.zeros(data.shape, dtype='complex64')
-    patches = op.diffraction.patch.fwd(
-        patches=patches,
-        images=psi,
-        positions=scan,
-        patch_width=varying_probe.shape[-1],
-    )
-    patches = patches.reshape(*scan.shape[:-1], 1, 1, op.detector_shape,
-                              op.detector_shape)
-
-    nearplane = cp.tile(patches, reps=(1, 1, varying_probe.shape[-3], 1, 1))
-    pad, end = op.diffraction.pad, op.diffraction.end
-    nearplane[..., pad:end, pad:end] *= varying_probe
-
-    # Solve the farplane phase problem ----------------------------------------
-    farplane = op.propagation.fwd(nearplane, overwrite=True)
+    farplane = op.fwd(probe=varying_probe, scan=scan, psi=psi)
     intensity = cp.sum(
         cp.square(cp.abs(farplane)),
         axis=list(range(1, farplane.ndim - 2)),

--- a/src/tike/ptycho/solvers/epie.py
+++ b/src/tike/ptycho/solvers/epie.py
@@ -110,25 +110,7 @@ def epie(
 
 def _update_wavefront(data, varying_probe, scan, psi, op=None):
 
-    # Compute the diffraction patterns for all of the probe modes at once.
-    # We need access to all of the modes of a position to solve the phase
-    # problem. The Ptycho operator doesn't do this natively, so it's messy.
-    patches = cp.zeros(data.shape, dtype='complex64')
-    patches = op.diffraction.patch.fwd(
-        patches=patches,
-        images=psi,
-        positions=scan,
-        patch_width=varying_probe.shape[-1],
-    )
-    patches = patches.reshape(*scan.shape[:-1], 1, 1, op.detector_shape,
-                              op.detector_shape)
-
-    nearplane = cp.tile(patches, reps=(1, 1, varying_probe.shape[-3], 1, 1))
-    pad, end = op.diffraction.pad, op.diffraction.end
-    nearplane[..., pad:end, pad:end] *= varying_probe
-
-    # Solve the farplane phase problem ----------------------------------------
-    farplane = op.propagation.fwd(nearplane, overwrite=True)
+    farplane = op.fwd(probe=varying_probe, scan=scan, psi=psi)
     intensity = cp.sum(
         cp.square(cp.abs(farplane)),
         axis=list(range(1, farplane.ndim - 2)),
@@ -141,6 +123,7 @@ def _update_wavefront(data, varying_probe, scan, psi, op=None):
 
     farplane = op.propagation.adj(farplane, overwrite=True)
 
+    pad, end = op.diffraction.pad, op.diffraction.end
     return farplane[..., pad:end, pad:end], cost
 
 

--- a/src/tike/view.py
+++ b/src/tike/view.py
@@ -460,3 +460,42 @@ def plot_trajectories(theta, v, h, t):
     plt.xlabel('time [s]')
     plt.ylim([0, 1.])
     return ax1a, ax1b
+
+
+def plot_cost_convergence(costs, times):
+    """Plot a twined plot of cost vs iteration/cumulative-time
+
+    The plot is a semi-log line plot with two lines. One line shows cost as a
+    function of iteration (bottom horizontal); one line shows cost as a
+    function of cumulative wall-time (top horizontal).
+
+    Parameters
+    ----------
+    costs : (NUM_ITER, ) array-like
+        The objective cost at each iteration.
+    times : (NUM_ITER, ) array-like
+        The wall-time for each iteration in seconds.
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+    ax1 : matplotlib.axes._subplots.AxesSubplot
+    ax2 : matplotlib.axes._subplots.AxesSubplot
+    """
+    fig, ax1 = plt.subplots()
+
+    color = 'black'
+    ax1.semilogy()
+    ax1.set_xlabel('iteration', color=color)
+    ax1.set_ylabel('objective')
+    ax1.plot(costs, linestyle='--', color=color)
+    ax1.tick_params(axis='x', labelcolor=color)
+
+    ax2 = ax1.twiny()
+
+    color = 'red'
+    ax2.set_xlabel('wall-time [s]', color=color)
+    ax2.plot(np.cumsum(times), costs, color=color)
+    ax2.tick_params(axis='x', labelcolor=color)
+
+    return fig, ax1, ax2

--- a/tests/operators/test_convolution.py
+++ b/tests/operators/test_convolution.py
@@ -117,9 +117,12 @@ class TestConvolution(unittest.TestCase, OperatorTests):
         b = inner_complex(self.m, m)
         c = inner_complex(self.m1, m1)
         print()
-        print('< Fm,    m> = {:.6f}{:+.6f}j'.format(a.real.item(), a.imag.item()))
-        print('< d0, F*d0> = {:.6f}{:+.6f}j'.format(b.real.item(), b.imag.item()))
-        print('< d1, F*d1> = {:.6f}{:+.6f}j'.format(c.real.item(), c.imag.item()))
+        print('< Fm,    m> = {:.6f}{:+.6f}j'.format(a.real.item(),
+                                                    a.imag.item()))
+        print('< d0, F*d0> = {:.6f}{:+.6f}j'.format(b.real.item(),
+                                                    b.imag.item()))
+        print('< d1, F*d1> = {:.6f}{:+.6f}j'.format(c.real.item(),
+                                                    c.imag.item()))
         self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
         self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
         self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-5, atol=0)

--- a/tests/operators/test_convolution.py
+++ b/tests/operators/test_convolution.py
@@ -79,8 +79,8 @@ class TestConvolution(unittest.TestCase, OperatorTests):
         print()
         print('<Fm,   m> = {:.6f}{:+.6f}j'.format(a.real.item(), a.imag.item()))
         print('< d, F*d> = {:.6f}{:+.6f}j'.format(b.real.item(), b.imag.item()))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5)
-        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
 
     def test_adj_probe_time(self):
         """Time the adjoint operation."""
@@ -93,7 +93,7 @@ class TestConvolution(unittest.TestCase, OperatorTests):
     def test_scaled(self):
         pass
 
-    def test_adjoint_both(self):
+    def test_adjoint_all(self):
         """Check that the adjoint operator is correct."""
         d = self.operator.fwd(
             **{
@@ -103,7 +103,7 @@ class TestConvolution(unittest.TestCase, OperatorTests):
             **self.kwargs2,
         )
         assert d.shape == self.d.shape
-        m, m1 = self.operator.adj_both(
+        m, m1 = self.operator.adj_all(
             **{
                 self.d_name: self.d,
                 self.m_name: self.m,
@@ -120,10 +120,10 @@ class TestConvolution(unittest.TestCase, OperatorTests):
         print('< Fm,    m> = {:.6f}{:+.6f}j'.format(a.real.item(), a.imag.item()))
         print('< d0, F*d0> = {:.6f}{:+.6f}j'.format(b.real.item(), b.imag.item()))
         print('< d1, F*d1> = {:.6f}{:+.6f}j'.format(c.real.item(), c.imag.item()))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5)
-        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
-        self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-5)
-        self.xp.testing.assert_allclose(a.imag, c.imag, rtol=1e-5)
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.imag, c.imag, rtol=1e-5, atol=0)
 
 
 if __name__ == '__main__':

--- a/tests/operators/test_ptycho.py
+++ b/tests/operators/test_ptycho.py
@@ -119,13 +119,17 @@ class TestPtycho(unittest.TestCase, OperatorTests):
         b = inner_complex(self.m, m)
         c = inner_complex(self.m1, m1)
         print()
-        print('< Fm,    m> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
-        print('< d0, F*d0> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
-        print('< d1, F*d1> = {:.5g}{:+.5g}j'.format(c.real.item(), c.imag.item()))
+        print('< Fm,    m> = {:.5g}{:+.5g}j'.format(a.real.item(),
+                                                    a.imag.item()))
+        print('< d0, F*d0> = {:.5g}{:+.5g}j'.format(b.real.item(),
+                                                    b.imag.item()))
+        print('< d1, F*d1> = {:.5g}{:+.5g}j'.format(c.real.item(),
+                                                    c.imag.item()))
         self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
         self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
         self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-5, atol=0)
         self.xp.testing.assert_allclose(a.imag, c.imag, rtol=1e-5, atol=0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/operators/test_ptycho.py
+++ b/tests/operators/test_ptycho.py
@@ -63,6 +63,9 @@ class TestPtycho(unittest.TestCase, OperatorTests):
             'scan': self.xp.asarray(scan, dtype='float32'),
             'psi': self.xp.asarray(original, dtype='complex64')
         }
+        self.kwargs2 = {
+            'scan': self.xp.asarray(scan, dtype='float32'),
+        }
 
         self.d = self.xp.asarray(farplane, dtype='complex64')
         self.d_name = 'farplane'
@@ -76,10 +79,10 @@ class TestPtycho(unittest.TestCase, OperatorTests):
         a = inner_complex(d, self.d)
         b = inner_complex(self.m1, m)
         print()
-        print('<Fm,   m> = {:.6f}{:+.6f}j'.format(a.real.item(), a.imag.item()))
-        print('< d, F*d> = {:.6f}{:+.6f}j'.format(b.real.item(), b.imag.item()))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5)
-        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
+        print('<Fm,   m> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
+        print('< d, F*d> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
 
     def test_adj_probe_time(self):
         """Time the adjoint operation."""
@@ -92,6 +95,37 @@ class TestPtycho(unittest.TestCase, OperatorTests):
     def test_scaled(self):
         pass
 
+    def test_adjoint_all(self):
+        """Check that the adjoint operator is correct."""
+        d = self.operator.fwd(
+            **{
+                self.m_name: self.m,
+                self.m1_name: self.m1
+            },
+            **self.kwargs2,
+        )
+        assert d.shape == self.d.shape
+        m, m1 = self.operator.adj_all(
+            **{
+                self.d_name: self.d,
+                self.m_name: self.m,
+                self.m1_name: self.m1
+            },
+            **self.kwargs2,
+        )
+        assert m.shape == self.m.shape
+        assert m1.shape == self.m1.shape
+        a = inner_complex(d, self.d)
+        b = inner_complex(self.m, m)
+        c = inner_complex(self.m1, m1)
+        print()
+        print('< Fm,    m> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
+        print('< d0, F*d0> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
+        print('< d1, F*d1> = {:.5g}{:+.5g}j'.format(c.real.item(), c.imag.item()))
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.imag, c.imag, rtol=1e-5, atol=0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/operators/util.py
+++ b/tests/operators/util.py
@@ -45,10 +45,10 @@ class OperatorTests():
         a = inner_complex(d, self.d)
         b = inner_complex(self.m, m)
         print()
-        print('<Fm,   m> = {:.6f}{:+.6f}j'.format(a.real.item(), a.imag.item()))
-        print('< d, F*d> = {:.6f}{:+.6f}j'.format(b.real.item(), b.imag.item()))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5)
-        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5)
+        print('<Fm,   m> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
+        print('< d, F*d> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
 
     def test_scaled(self):
         """Check that the adjoint operator is scaled."""
@@ -60,11 +60,12 @@ class OperatorTests():
         a = inner_complex(m, m)
         b = inner_complex(self.m, self.m)
         print()
-        print('<F*Fm, F*Fm> = {:.6f}{:+.6f}j'.format(a.real.item(),
-                                                     a.imag.item()))
-        print('<   m,    m> = {:.6f}{:+.6f}j'.format(b.real.item(),
-                                                     b.imag.item()))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5)
+        # NOTE: Inner product with self is real-only magnitude of self
+        print('<F*Fm, F*Fm> = {:.5g}{:+.5g}j'.format(a.real.item(),
+                                                     0))
+        print('<   m,    m> = {:.5g}{:+.5g}j'.format(b.real.item(),
+                                                     0))
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
 
     def test_fwd_time(self):
         """Time the forward operation."""

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -486,7 +486,7 @@ def _save_ptycho_result(result, algorithm):
         ax1.semilogy()
         ax1.set_xlabel('iteration', color=color)
         ax1.set_ylabel('objective')
-        ax1.plot(result['costs'], lineStyle='--', color=color)
+        ax1.plot(result['costs'], linestyle='--', color=color)
         ax1.tick_params(axis='x', labelcolor=color)
         ax1.set_ylim(10**-1, 10**1)
 

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -490,18 +490,20 @@ def _save_ptycho_result(result, algorithm):
         plt.title(algorithm)
 
         color = 'black'
-        ax1.set_xlabel('iteration')
-        ax1.set_ylabel('objective', color=color)
-        ax1.plot(result['costs'], color=color)
-        ax1.tick_params(axis='y', labelcolor=color)
         ax1.semilogy()
+        ax1.set_xlabel('iteration', color=color)
+        ax1.set_ylabel('objective')
+        ax1.plot(result['costs'], lineStyle='--', color=color)
+        ax1.tick_params(axis='x', labelcolor=color)
+        ax1.set_ylim(10**-1, 10**1)
 
-        ax2 = ax1.twinx()
+        ax2 = ax1.twiny()
 
         color = 'red'
-        ax2.set_ylabel('times-per-iteration [s]', color=color)
-        ax2.plot(result['times'], color=color)
-        ax2.tick_params(axis='y', labelcolor=color)
+        ax2.set_xlabel('wall-time [s]', color=color)
+        ax2.plot(np.cumsum(result['times']), result['costs'], color=color)
+        ax2.tick_params(axis='x', labelcolor=color)
+        ax2.set_xlim(0, 20)
         fig.tight_layout()
 
         plt.savefig(os.path.join(fname, 'convergence.svg'))

--- a/tests/test_ptycho.py
+++ b/tests/test_ptycho.py
@@ -476,27 +476,17 @@ def _save_probe(output_folder, probe):
 def _save_ptycho_result(result, algorithm):
     try:
         import matplotlib.pyplot as plt
+        import tike.view
         fname = os.path.join(testdir, 'result', 'ptycho', f'{algorithm}')
         os.makedirs(fname, exist_ok=True)
 
-        fig, ax1 = plt.subplots()
-        plt.title(algorithm)
-
-        color = 'black'
-        ax1.semilogy()
-        ax1.set_xlabel('iteration', color=color)
-        ax1.set_ylabel('objective')
-        ax1.plot(result['costs'], linestyle='--', color=color)
-        ax1.tick_params(axis='x', labelcolor=color)
-        ax1.set_ylim(10**-1, 10**1)
-
-        ax2 = ax1.twiny()
-
-        color = 'red'
-        ax2.set_xlabel('wall-time [s]', color=color)
-        ax2.plot(np.cumsum(result['times']), result['costs'], color=color)
-        ax2.tick_params(axis='x', labelcolor=color)
+        fig, ax1, ax2, = tike.view.plot_cost_convergence(
+            result['costs'],
+            result['times'],
+        )
         ax2.set_xlim(0, 20)
+        ax1.set_ylim(10**-1, 10**1)
+        fig.suptitle(algorithm)
         fig.tight_layout()
 
         plt.savefig(os.path.join(fname, 'convergence.svg'))


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
We can save a few FFTs by computing the adjoint for the object and probe simultaneously. This PR implements that functionality. Also, suspiciously the operators module is looking very similar to the Pytorch framework.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Implemented the adjoint operator for Ptycho that does both probe and object at the same time. Positions are still assume to be constant though. Also dropped in the Ptycho forward operation into epie and lstsq_grad where there was some old code from before Ptycho could handle multiple probes simultaneously.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [x] Write tests for new functions or explain why they are not needed.
- [ ] Build the documentation successfully
- [x] Use [`yapf`](https://github.com/google/yapf) to format python code.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
