### PR TITLE
BUG: Fix illegal memory access errors

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,11 @@ jobs:
 
   - script: |
       source activate tike
+      python tests/print-gpu-info.py
+    displayName: Print GPU info
+
+  - script: |
+      source activate tike
       pytest -vs
     displayName: Run tests
 
@@ -104,6 +109,11 @@ jobs:
       source activate tike
       pip install . --no-deps
     displayName: Setup and install
+
+  - script: |
+      source activate tike
+      python tests/print-gpu-info.py
+    displayName: Print GPU info
 
   - script: |
       source activate tike

--- a/src/tike/communicators/pool.py
+++ b/src/tike/communicators/pool.py
@@ -202,7 +202,7 @@ class ThreadPool(ThreadPoolExecutor):
     def reduce_cpu(self, x, buf=None):
         """Reduce x by addition from all GPUs to a CPU buffer."""
         buf = 0 if buf is None else buf
-        buf += sum([self.xp.asnumpy(part) for part in x])
+        buf += sum(self.map(self.xp.asnumpy, x))
         return buf
 
     def reduce_mean(self, x: list, axis, worker=None) -> cp.array:

--- a/src/tike/operators/cupy/__init__.py
+++ b/src/tike/operators/cupy/__init__.py
@@ -6,6 +6,7 @@ launches and memory management may by accessed from Python.
 """
 
 from .alignment import *
+from .cache import *
 from .convolution import *
 from .flow import *
 from .lamino import *

--- a/src/tike/operators/cupy/cache.py
+++ b/src/tike/operators/cupy/cache.py
@@ -1,9 +1,13 @@
 __author__ = "Daniel Ching"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
-import cupy as cp
+import cupy.fft.config
 from cupyx.scipy.fft import fftn, ifftn
 from cupyx.scipy.fftpack import get_fft_plan
+from numpy.lib.utils import deprecate
+
+# NOTE: Keep this setting change even if class below is removed
+cupy.fft.config.enable_nd_planning = True
 
 
 class CachedFFT():
@@ -32,14 +36,23 @@ class CachedFFT():
             self.plan_cache[key] = plan
         return plan
 
+    @deprecate(
+        message='cupy>=8.0 ships an automatic plan cache enabled by default. '
+        'Use CuPy FFT functions directly.')
     def _fft2(self, a, *args, overwrite=False, **kwargs):
         with self._get_fft_plan(a, **kwargs):
             return fftn(a, *args, overwrite_x=overwrite, **kwargs)
 
+    @deprecate(
+        message='cupy>=8.0 ships an automatic plan cache enabled by default. '
+        'Use CuPy FFT functions directly.')
     def _ifft2(self, a, *args, overwrite=False, **kwargs):
         with self._get_fft_plan(a, **kwargs):
             return ifftn(a, *args, overwrite_x=overwrite, **kwargs)
 
+    @deprecate(
+        message='cupy>=8.0 ships an automatic plan cache enabled by default. '
+        'Use CuPy FFT functions directly.')
     def _fftn(self, a, *args, overwrite=False, **kwargs):
         with self._get_fft_plan(a, **kwargs):
             return fftn(a, *args, overwrite_x=overwrite, **kwargs)

--- a/src/tike/operators/cupy/lamino.py
+++ b/src/tike/operators/cupy/lamino.py
@@ -8,9 +8,9 @@ except ImportError:
     from importlib_resources import files
 
 import cupy as cp
+import cupyx.scipy.fft
 import numpy as np
 
-from .cache import CachedFFT
 from .usfft import eq2us, us2eq, checkerboard
 from .operator import Operator
 
@@ -18,7 +18,11 @@ _cu_source = files('tike.operators.cupy').joinpath('grid.cu').read_text()
 _make_grids_kernel = cp.RawKernel(_cu_source, "make_grids")
 
 
-class Lamino(CachedFFT, Operator):
+def _fftn(*args, **kwargs):
+    return cupyx.scipy.fft.fftn(*args, overwrite_x=True, **kwargs)
+
+
+class Lamino(Operator):
     """A Laminography operator.
 
     Laminography operators to simulate propagation of the beam through the
@@ -53,20 +57,10 @@ class Lamino(CachedFFT, Operator):
         self.eps = np.float32(eps)
         self.upsample = upsample
 
-    def __enter__(self):
-        """Return self at start of a with-block."""
-        CachedFFT.__enter__(self)
-        # Call the __enter__ methods for any composed operators.
-        # Allocate special memory objects.
-        return self
-
     def fwd(self, u, theta, **kwargs):
         """Perform the forward Laminography transform."""
 
         xi = self._make_grids(theta)
-
-        def fftn(*args, **kwargs):
-            return self._fftn(*args, overwrite=True, **kwargs)
 
         # USFFT from equally-spaced grid to unequally-spaced grid
         F = eq2us(
@@ -75,21 +69,21 @@ class Lamino(CachedFFT, Operator):
             self.n,
             self.eps,
             self.xp,
-            fftn=fftn,
+            fftn=_fftn,
             upsample=self.upsample,
         ).reshape([theta.shape[-1], self.n, self.n])
 
         # Inverse 2D FFT
         data = checkerboard(
             self.xp,
-            self._ifft2(
+            cupyx.scipy.fft.ifft2(
                 checkerboard(
                     self.xp,
                     F,
                     axes=(1, 2),
                 ),
                 axes=(1, 2),
-                overwrite=True,
+                overwrite_x=True,
             ),
             axes=(1, 2),
             inverse=True,
@@ -101,20 +95,17 @@ class Lamino(CachedFFT, Operator):
 
         xi = self._make_grids(theta)
 
-        def fftn(*args, **kwargs):
-            return self._fftn(*args, overwrite=True, **kwargs)
-
         # Forward 2D FFT
         F = checkerboard(
             self.xp,
-            self._fft2(
+            cupyx.scipy.fft.fft2(
                 checkerboard(
                     self.xp,
                     data.copy() if not overwrite else data,
                     axes=(1, 2),
                 ),
                 axes=(1, 2),
-                overwrite=True,
+                overwrite_x=True,
             ),
             axes=(1, 2),
             inverse=True,
@@ -127,7 +118,7 @@ class Lamino(CachedFFT, Operator):
             self.n,
             self.eps,
             self.xp,
-            fftn=fftn,
+            fftn=_fftn,
             upsample=self.upsample,
         )
         u /= self.n**2

--- a/src/tike/operators/cupy/propagation.py
+++ b/src/tike/operators/cupy/propagation.py
@@ -3,13 +3,13 @@
 __author__ = "Daniel Ching, Viktor Nikitin"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
-from .cache import CachedFFT
-from .operator import Operator
-
+import cupyx.scipy.fft
 import numpy as np
 
+from .operator import Operator
 
-class Propagation(CachedFFT, Operator):
+
+class Propagation(Operator):
     """A Fourier-based free-space propagation using CuPy.
 
     Take an (..., N, N) array and apply the Fourier transform to the last two
@@ -49,22 +49,22 @@ class Propagation(CachedFFT, Operator):
         """Forward Fourier-based free-space propagation operator."""
         self._check_shape(nearplane)
         shape = nearplane.shape
-        return self._fft2(
+        return cupyx.scipy.fft.fft2(
             nearplane.reshape(-1, self.detector_shape, self.detector_shape),
             norm='ortho',
             axes=(-2, -1),
-            overwrite=overwrite,
+            overwrite_x=overwrite,
         ).reshape(shape)
 
     def adj(self, farplane, overwrite=False, **kwargs):
         """Adjoint Fourier-based free-space propagation operator."""
         self._check_shape(farplane)
         shape = farplane.shape
-        return self._ifft2(
+        return cupyx.scipy.fft.ifft2(
             farplane.reshape(-1, self.detector_shape, self.detector_shape),
             norm='ortho',
             axes=(-2, -1),
-            overwrite=overwrite,
+            overwrite_x=overwrite,
         ).reshape(shape)
 
     def _check_shape(self, x):

--- a/src/tike/operators/cupy/shift.py
+++ b/src/tike/operators/cupy/shift.py
@@ -1,11 +1,11 @@
 __author__ = "Daniel Ching, Viktor Nikitin"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
-from .cache import CachedFFT
+import cupyx.scipy.fft
 from .operator import Operator
 
 
-class Shift(CachedFFT, Operator):
+class Shift(Operator):
     """Shift last two dimensions of an array using Fourier method."""
 
     def fwd(self, a, shift, overwrite=False, cval=None):
@@ -23,7 +23,7 @@ class Shift(CachedFFT, Operator):
             return a
         shape = a.shape
         padded = a.reshape(-1, *shape[-2:])
-        padded = self._fft2(padded, axes=(-2, -1), overwrite=overwrite)
+        padded = cupyx.scipy.fft.fft2(padded, axes=(-2, -1), overwrite_x=overwrite)
         x, y = self.xp.meshgrid(
             self.xp.fft.fftfreq(padded.shape[-1]).astype('float32'),
             self.xp.fft.fftfreq(padded.shape[-2]).astype('float32'),
@@ -31,7 +31,7 @@ class Shift(CachedFFT, Operator):
         padded *= self.xp.exp(
             -2j * self.xp.pi *
             (x * shift[..., 1, None, None] + y * shift[..., 0, None, None]))
-        padded = self._ifft2(padded, axes=(-2, -1), overwrite=True)
+        padded = cupyx.scipy.fft.ifft2(padded, axes=(-2, -1), overwrite_x=True)
         return padded.reshape(*shape)
 
     def adj(self, a, shift, overwrite=False, cval=None):

--- a/src/tike/operators/cupy/shift.py
+++ b/src/tike/operators/cupy/shift.py
@@ -23,7 +23,11 @@ class Shift(Operator):
             return a
         shape = a.shape
         padded = a.reshape(-1, *shape[-2:])
-        padded = cupyx.scipy.fft.fft2(padded, axes=(-2, -1), overwrite_x=overwrite)
+        padded = cupyx.scipy.fft.fft2(
+            padded,
+            axes=(-2, -1),
+            overwrite_x=overwrite,
+        )
         x, y = self.xp.meshgrid(
             self.xp.fft.fftfreq(padded.shape[-1]).astype('float32'),
             self.xp.fft.fftfreq(padded.shape[-2]).astype('float32'),

--- a/tests/print-gpu-info.py
+++ b/tests/print-gpu-info.py
@@ -1,0 +1,13 @@
+import cupy
+import pprint
+
+if __name__ == '__main__':
+
+    pp = pprint.PrettyPrinter()
+
+    print(f'CUDA driver version is  {cupy.cuda.runtime.driverGetVersion()}\n'
+          f'CUDA runtime version is {cupy.cuda.runtime.runtimeGetVersion()}\n')
+
+    for i in range(cupy.cuda.runtime.getDeviceCount()):
+        print(f'Properties for device {i}:')
+        pp.pprint(cupy.cuda.runtime.getDeviceProperties(i))


### PR DESCRIPTION
Fixes two sources of error only observed in multi-GPU mode. 1. memory was being copied to the host from the gpu without setting the correct device context. 2. FFT plan cache was being used without setting the correct device context.