### PR TITLE
Fix memory leak due to CuPy automatic FFT Cache

### DIFF
--- a/src/tike/operators/cupy/propagation.py
+++ b/src/tike/operators/cupy/propagation.py
@@ -8,6 +8,7 @@ import numpy as np
 from .cache import CachedFFT
 from .operator import Operator
 
+
 class Propagation(CachedFFT, Operator):
     """A Fourier-based free-space propagation using CuPy.
 

--- a/src/tike/operators/cupy/propagation.py
+++ b/src/tike/operators/cupy/propagation.py
@@ -3,13 +3,12 @@
 __author__ = "Daniel Ching, Viktor Nikitin"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
-import cupyx.scipy.fft
 import numpy as np
 
+from .cache import CachedFFT
 from .operator import Operator
 
-
-class Propagation(Operator):
+class Propagation(CachedFFT, Operator):
     """A Fourier-based free-space propagation using CuPy.
 
     Take an (..., N, N) array and apply the Fourier transform to the last two
@@ -49,7 +48,7 @@ class Propagation(Operator):
         """Forward Fourier-based free-space propagation operator."""
         self._check_shape(nearplane)
         shape = nearplane.shape
-        return cupyx.scipy.fft.fft2(
+        return self._fft2(
             nearplane.reshape(-1, self.detector_shape, self.detector_shape),
             norm='ortho',
             axes=(-2, -1),
@@ -60,7 +59,7 @@ class Propagation(Operator):
         """Adjoint Fourier-based free-space propagation operator."""
         self._check_shape(farplane)
         shape = farplane.shape
-        return cupyx.scipy.fft.ifft2(
+        return self._ifft2(
             farplane.reshape(-1, self.detector_shape, self.detector_shape),
             norm='ortho',
             axes=(-2, -1),

--- a/src/tike/operators/cupy/shift.py
+++ b/src/tike/operators/cupy/shift.py
@@ -1,11 +1,11 @@
 __author__ = "Daniel Ching, Viktor Nikitin"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 
-import cupyx.scipy.fft
+from .cache import CachedFFT
 from .operator import Operator
 
 
-class Shift(Operator):
+class Shift(CachedFFT, Operator):
     """Shift last two dimensions of an array using Fourier method."""
 
     def fwd(self, a, shift, overwrite=False, cval=None):
@@ -23,7 +23,7 @@ class Shift(Operator):
             return a
         shape = a.shape
         padded = a.reshape(-1, *shape[-2:])
-        padded = cupyx.scipy.fft.fft2(
+        padded = self._fft2(
             padded,
             axes=(-2, -1),
             overwrite_x=overwrite,
@@ -35,7 +35,7 @@ class Shift(Operator):
         padded *= self.xp.exp(
             -2j * self.xp.pi *
             (x * shift[..., 1, None, None] + y * shift[..., 0, None, None]))
-        padded = cupyx.scipy.fft.ifft2(padded, axes=(-2, -1), overwrite_x=True)
+        padded = self._ifft2(padded, axes=(-2, -1), overwrite_x=True)
         return padded.reshape(*shape)
 
     def adj(self, a, shift, overwrite=False, cval=None):

--- a/src/tike/ptycho/position.py
+++ b/src/tike/ptycho/position.py
@@ -204,13 +204,13 @@ def update_positions_pd(operator, data, psi, probe, scan,
     return scan, cost
 
 
-def _image_grad(x):
+def _image_grad(op, x):
     """Return the gradient of the x for each of the last two dimesions."""
     # FIXME: Use different gradient approximation that does not use FFT. Because
     # FFT caches are per-thread and per-device, using FFT is inefficient.
     ramp = 2j * cp.pi * cp.linspace(-0.5, 0.5, x.shape[-1], dtype='float32')
-    grad_x = cupyx.scipy.fft.ifft2(ramp[:, None] * cupyx.scipy.fft.fft2(x))
-    grad_y = cupyx.scipy.fft.ifft2(ramp * cupyx.scipy.fft.fft2(x))
+    grad_x = op.propagation._ifft2(ramp[:, None] * op.propagation._fft2(x))
+    grad_y = op.propagation._ifft2(ramp * op.propagation._fft2(x))
     return grad_x, grad_y
 
 
@@ -278,7 +278,7 @@ def affine_position_regularization(
     X, Y = cp.mgrid[-ny // 2:ny // 2, -nx // 2:nx // 2]
     spatial_filter = cp.exp(-(X**16 + Y**16) / (min(nx, ny) / 2.2)**16)
     obj_proj *= spatial_filter
-    dX, dY = _image_grad(obj_proj)
+    dX, dY = _image_grad(op, obj_proj)
 
     illum = probe[..., :, 0, 0, :, :]
     illum = illum * illum.conj()
@@ -289,7 +289,7 @@ def affine_position_regularization(
         images=cp.zeros(psi.shape, dtype='complex64'),
         positions=updated,
     )
-    total_illumination = cupyx.scipy.fft.fft2(total_illumination)
+    total_illumination = op.propagation._fft2(total_illumination)
     total_illumination *= _gaussian_frequency(
         sigma=sigma,
         size=total_illumination.shape[-1],
@@ -298,7 +298,7 @@ def affine_position_regularization(
         sigma=sigma,
         size=total_illumination.shape[-2],
     )[..., None]
-    total_illumination = cupyx.scipy.fft.ifft2(total_illumination)
+    total_illumination = op.propagation._ifft2(total_illumination)
     illum_proj = op.diffraction.patch.fwd(
         images=total_illumination,
         positions=updated,

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -246,14 +246,17 @@ def reconstruct(
     else:
         mpi = None
     check_allowed_positions(scan, psi, probe.shape)
-    with cp.cuda.Device(num_gpu[0] if isinstance(num_gpu, tuple) else None):
+    with (
+        cp.cuda.Device(num_gpu[0] if isinstance(num_gpu, tuple) else None),
+        Comm(num_gpu, mpi) as comm
+    ):
         with Ptycho(
                 probe_shape=probe.shape[-1],
                 detector_shape=data.shape[-1],
                 nz=psi.shape[-2],
                 n=psi.shape[-1],
                 model=model,
-        ) as operator, Comm(num_gpu, mpi) as comm:
+        ) as operator:
 
             (
                 batches,

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -246,17 +246,14 @@ def reconstruct(
     else:
         mpi = None
     check_allowed_positions(scan, psi, probe.shape)
-    with (
-        cp.cuda.Device(num_gpu[0] if isinstance(num_gpu, tuple) else None),
-        Comm(num_gpu, mpi) as comm
-    ):
+    with (cp.cuda.Device(num_gpu[0] if isinstance(num_gpu, tuple) else None)):
         with Ptycho(
                 probe_shape=probe.shape[-1],
                 detector_shape=data.shape[-1],
                 nz=psi.shape[-2],
                 n=psi.shape[-1],
                 model=model,
-        ) as operator:
+        ) as operator, Comm(num_gpu, mpi) as comm:
 
             (
                 batches,
@@ -302,17 +299,17 @@ def reconstruct(
                 algorithm_options.times.append(time.perf_counter() - start)
                 start = time.perf_counter()
 
-        return _teardown(
-            algorithm_options,
-            comm,
-            eigen_probe,
-            eigen_weights,
-            object_options,
-            position_options,
-            probe_options,
-            result,
-            scan,
-        )
+            return _teardown(
+                algorithm_options,
+                comm,
+                eigen_probe,
+                eigen_weights,
+                object_options,
+                position_options,
+                probe_options,
+                result,
+                scan,
+            )
 
 
 def _setup(

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -283,7 +283,8 @@ def reconstruct(
 
                 logger.info(f"{algorithm_options.name} epoch {i:,d}")
 
-                # TODO: Append new information to everything that emits from _setup.
+                # TODO: Append new information to everything that emits from
+                # _setup.
 
                 result = _iterate(
                     algorithm_options,

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -514,6 +514,7 @@ def _update_nearplane(op, comm, nearplane, psi, scan_, probe, unique_probe,
                 scan_,
                 unique_probe,
                 m=m,
+                op=op,
             ))
 
     return psi, probe, eigen_probe, eigen_weights, scan_, position_options
@@ -556,13 +557,14 @@ def _update_position(
     scan,
     unique_probe,
     m,
+    op,
 ):
     main_probe = unique_probe[..., m:m + 1, :, :]
 
     # According to the manuscript, we can either shift the probe or the object
     # and they are equivalent (in theory). Here we shift the object because
     # that is what ptychoshelves does.
-    grad_x, grad_y = _image_grad(patches)
+    grad_x, grad_y = _image_grad(op, patches)
 
     numerator = cp.sum(cp.real(diff * cp.conj(grad_x * main_probe)),
                        axis=(-2, -1))

--- a/src/tike/ptycho/solvers/rpie.py
+++ b/src/tike/ptycho/solvers/rpie.py
@@ -322,7 +322,7 @@ def _get_nearplane_gradients(
     position_update_numerator = cp.zeros(scan.shape, dtype='float32')
     position_update_denominator = cp.zeros(scan.shape, dtype='float32')
 
-    grad_x, grad_y = _image_grad(patches)
+    grad_x, grad_y = _image_grad(op, patches)
 
     for m in range(probe.shape[-3]):
 


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Fixes #187. Because we use a modified ThreadPool.map() to ensure that CuPy arrays are always operated on in the correct device context, the automatic FFT plan cache from CuPy does not work correctly. This is because the cache is not (cannot be?) cleared automatically when the thread pool is destroyed because the threads don't know when they will be destroyed, so it exists beyond the life of the threads in the ThreadPool. This leads to a memory leak because if a new Comm object is created, then new threads create new FFT caches that are never destroyed. There is no way to disable the automatic cache globally (that I know of).

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
We solve this problem by reverting to our custom cache which only caches per device and is directly tied to the life of the Operator using the FFTs. This way, the cache is always destroyed when the Operator goes out of scope regardless of whether the threads are alive/dead.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [x] Click 'details' on the readthedocs check to view the updated docs.
- [x] Write tests for new functions or explain why they are not needed.
- [x] Address any complaints from pep8speaks.

### Reviewer
- [x] Actually read all of the code.
- [x] Run the new code yourself; the included tests should make this easy.
- [x] Write a summary of the changes as you understand them.
- [x] Thank the submitter.
