### PR TITLE
API: Raise ValueError when ptycho input shapes are wrong

### DIFF
--- a/src/tike/ptycho/position.py
+++ b/src/tike/ptycho/position.py
@@ -113,7 +113,7 @@ def check_allowed_positions(scan: np.array, psi: np.array, probe_shape: tuple):
     Raises
     ------
     ValueError
-        The field of view must have 1 pixel buffer around the edge. i.e.
+        The field of view must have 2 pixel buffer around the edge. i.e.
         positions must be >= 2 and < the object.shape - 2 - probe.shape. This
         padding is to allow approximating gradients and to provide better
         interpolation near the edges of the field of view.

--- a/src/tike/ptycho/position.py
+++ b/src/tike/ptycho/position.py
@@ -107,13 +107,16 @@ class PositionOptions:
         self._momentum[..., 3] = x
 
 
-def check_allowed_positions(scan, psi, probe_shape):
+def check_allowed_positions(scan: np.array, psi: np.array, probe_shape: tuple):
     """Check that all positions are within the field of view.
 
-    The field of view must have 1 pixel buffer around the edge. i.e. positions
-    must be >= 1 and < the object shape - 1 - probe.shape. This padding is to
-    allow approximating gradients and to provide better interpolation near the
-    edges of the field of view.
+    Raises
+    ------
+    ValueError
+        The field of view must have 1 pixel buffer around the edge. i.e.
+        positions must be >= 2 and < the object.shape - 2 - probe.shape. This
+        padding is to allow approximating gradients and to provide better
+        interpolation near the edges of the field of view.
     """
     int_scan = scan // 1
     less_than_one = int_scan < 1
@@ -124,11 +127,12 @@ def check_allowed_positions(scan, psi, probe_shape):
     )
     if np.any(less_than_one) or np.any(greater_than_psi):
         x = np.logical_or(less_than_one, greater_than_psi)
-        raise ValueError("Scan positions must be positive valued "
-                         "and fit within the field of view "
-                         "with at least a 1 pixel buffer around the edge. "
-                         "These scan positions exist outside field of view:\n"
-                         f"{scan[np.logical_or(x[..., 0], x[..., 1])]}")
+        raise ValueError(
+            "Scan positions must be >= 2 and "
+            "scan positions + 2 + probe.shape must be < object.shape. "
+            "psi may be too small or the scan positions may be scaled wrong. "
+            "These scan positions exist outside field of view:\n"
+            f"{scan[np.logical_or(x[..., 0], x[..., 1])]}")
 
 
 def update_positions_pd(operator, data, psi, probe, scan,

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -222,6 +222,11 @@ def reconstruct(
     use_mpi : bool
         Whether to use MPI or not.
 
+    Raises
+    ------
+        ValueError
+            When shapes are incorrect for various input parameters.
+
     Returns
     -------
     result : dict
@@ -229,6 +234,37 @@ def reconstruct(
         function to resume reconstruction from the previous state.
 
     """
+    if (np.any(np.asarray(data.shape) < 1) or data.ndim != 3
+            or data.shape[-2] != data.shape[-1]):
+        raise ValueError(
+            f"data shape {data.shape} is incorrect. "
+            "It should be (N, W, H), "
+            "where N >= 1 is the number of square diffraction patterns.")
+    if (scan.ndim != 2 or scan.shape[1] != 2
+            or np.any(np.asarray(scan.shape) < 1)):
+        raise ValueError(f"scan shape {scan.shape} is incorrect. "
+                         "It should be (N, 2) "
+                         "where N >= 1 is the number of scan positions.")
+    if data.shape[0] != scan.shape[0]:
+        raise ValueError(
+            f"data shape {data.shape} and scan shape {scan.shape} "
+            "are incompatible. They should have the same leading dimension.")
+    if (probe.ndim != 5 or probe.shape[:2] != (1, 1)
+            or np.any(np.asarray(probe.shape) < 1)
+            or probe.shape[-2] != probe.shape[-1]):
+        raise ValueError(f"probe shape {probe.shape} is incorrect. "
+                         "It should be (1, 1, S, W, H) "
+                         "where S >=1 is the number of probes, and "
+                         "W, H >= 1 are the square probe grid dimensions.")
+    if np.any(np.asarray(probe.shape[-2:]) > np.asarray(data.shape[-2:])):
+        raise ValueError(f"probe shape {probe.shape} is incorrect."
+                         "The probe width/height must be "
+                         f"<= the data width/height {data.shape}.")
+    if (psi.ndim != 2
+            or np.any(np.asarray(psi.shape) <= np.asarray(probe.shape[-2:]))):
+        raise ValueError(f"psi shape {psi.shape} is incorrect. "
+                         "It should be (W, H) where W, H > probe.shape[-2:].")
+    check_allowed_positions(scan, psi, probe.shape)
     logger.info("{} for {:,d} - {:,d} by {:,d} frames for {:,d} "
                 "iterations.".format(
                     algorithm_options.name,
@@ -245,7 +281,6 @@ def reconstruct(
                 "across processes.")
     else:
         mpi = None
-    check_allowed_positions(scan, psi, probe.shape)
     with (cp.cuda.Device(num_gpu[0] if isinstance(num_gpu, tuple) else None)):
         with Ptycho(
                 probe_shape=probe.shape[-1],


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Provide helpful feedback to programmers learning to use the tike.ptycho.reconstruct API.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Check (in earnest) all the main inputs of tike.ptycho.reconstruct for correct shapes and other geometric constraints.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [x] Click 'details' on the readthedocs check to view the updated docs.
- [x] Write tests for new functions or explain why they are not needed.
- [x] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
