### PR TITLE
API: Make psi parameter of tike.ptycho.reconstruct positional

### DIFF
--- a/src/tike/ptycho/io.py
+++ b/src/tike/ptycho/io.py
@@ -53,6 +53,7 @@ def read_aps_velociprobe(
         position_path,
         xy_columns=(5, 1),
         trigger_column=7,
+        max_crop=2048,
 ):
     """Load ptychography data from the Advanced Photon Source Velociprobe.
 
@@ -106,6 +107,9 @@ def read_aps_velociprobe(
     trigger_column : int
         The column in the 8 column raw position file to use for grouping
         positions together.
+    max_crop : int
+        Crop the diffraction pattern to at most this width.
+
     Returns
     -------
     data : (FRAME, WIDE, HIGH) float32
@@ -136,8 +140,10 @@ def read_aps_velociprobe(
 
         # Autodetect the diffraction pattern size by doubling until it
         # doesn't fit on the detector anymore.
+        max_radius = max_crop // 2
         radius = 2
-        while (beam_center_x + radius < detect_width
+        while (radius <= max_radius
+               and beam_center_x + radius < detect_width
                and beam_center_y + radius < detect_height
                and beam_center_x - radius >= 0 and beam_center_y - radius >= 0):
             radius *= 2

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -173,6 +173,7 @@ def simulate(
 def reconstruct(
     data,
     probe,
+    psi,
     scan,
     algorithm_options=solvers.RpieOptions(),
     eigen_probe=None,
@@ -182,7 +183,6 @@ def reconstruct(
     object_options=None,
     position_options=None,
     probe_options=None,
-    psi=None,
     use_mpi=False,
 ):
     """Solve the ptychography problem using the given `algorithm`.


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Realized that the psi parameter is required, but has a default value of None. This is left over from a previous API breaking change where I removed auto-initialization of psi. This fix moves psi to the position parameters, so that the error raised tells the user that psi is required instead of that `None` has no parameters.

Also, adds a parameter to the velociprobe data loader, so that the data cropping can be controlled by the user. 

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [ ] Write tests for new functions or explain why they are not needed.
- [x] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
